### PR TITLE
Update Params and Scripts of API Manager 2.6.0

### DIFF
--- a/modules/apim/manifests/init.pp
+++ b/modules/apim/manifests/init.pp
@@ -19,14 +19,16 @@
 class apim inherits apim::params {
 
   if $::osfamily == 'redhat' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.rpm'
-    $installer_provider = 'rpm'
-    $install_path = '/usr/lib64/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
+    $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.deb'
-    $installer_provider = 'dpkg'
-    $install_path = '/usr/lib/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
+    $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -45,25 +47,25 @@ class apim inherits apim::params {
     system => true,
   }
   # Ensure the installation directory is available
-  file { "/opt/${service_name}":
+  file { "/opt/${product}":
     ensure => 'directory',
     owner  => $user,
     group  => $user_group,
   }
 
   # Copy the installer to the directory
-  file { "/opt/${service_name}/${apim_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${apim_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 API Manager
-  package { $service_name:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${service_name}/${apim_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/apim/manifests/params.pp
+++ b/modules/apim/manifests/params.pp
@@ -22,12 +22,15 @@ class apim::params {
   $user_group = 'wso2'
   $user_home = '/home/$user'
   $user_group_id = 802
+  $product = 'wso2am'
+  $product_version = '2.6.0'
   $service_name = 'wso2am'
+
   $hostname = 'localhost'
   $mgt_hostname = 'localhost'
   $jdk_version = 'jdk1.8.0_192'
 
-  # Define the template
+  # Define the templates
   $start_script_template = 'bin/wso2server.sh'
   $template_list = [
     'repository/conf/api-manager.xml',
@@ -41,91 +44,65 @@ class apim::params {
     # 'repository/conf/tomcat/catalina-server.xml',
   ]
 
-
   # ----- api-manager.xml config params -----
-  $auth_manager = {
-    server_url                => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username                  => '${admin.username}',
-    password                  => '${admin.password}',
-    check_permission_remotely => 'false'
-  }
+  $auth_manager_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $auth_manager_username = '${admin.username}'
+  $auth_manager_password = '${admin.password}'
+  $auth_manager_check_permission_remotely = 'false'
 
-  $api_gateway = {
-    server_url          => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username            => '${admin.username}',
-    password            => '${admin.password}',
-    gateway_endpoint    => 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}',
-    gateway_ws_endpoint => 'ws://${carbon.local.ip}:9099'
-  }
+  $api_gateway_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_gateway_username = '${admin.username}'
+  $api_gateway_password = '${admin.password}'
+  $api_gateway_endpoint = 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}'
+  $api_gateway_ws_endpoint = 'ws://${carbon.local.ip}:9099'
 
-  $analytics = {
-    enable              => 'false',
-    sp_server_url       => '{tcp://localhost:7612}',
-    sp_username         => '${admin.username}',
-    sp_password         => '${admin.password}',
-    sp_restapi_url      => 'https://localhost:7444',
-    sp_restapi_username => '${admin.username}',
-    sp_restapi_password => '${admin.password}'
-  }
+  $analytics_enable = 'false'
+  $stream_processor_url = '{tcp://localhost:7612}'
+  $stream_processor_username = '${admin.username}'
+  $stream_processor_password = '${admin.password}'
+  $stream_processor_restapi_url = 'https://localhost:7444'
+  $stream_processor_restapi_username = '${admin.username}'
+  $stream_processor_restapi_password = '${admin.password}'
 
-  $api_store = {
-    url        => 'https://localhost:${mgt.transport.https.port}/store',
-    server_url => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username   => '${admin.username}',
-    password   => '${admin.password}'
-  }
+  $api_store_url = 'https://localhost:${mgt.transport.https.port}/store'
+  $api_store_server_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_store_username = '${admin.username}'
+  $api_store_password = '${admin.password}'
 
-  $api_publisher = {
-    url => 'https://localhost:${mgt.transport.https.port}/publisher'
-  }
+  $api_publisher_url = 'https://localhost:${mgt.transport.https.port}/publisher'
 
   # ----- Master-datasources config params -----
-  $wso2am_db = {
-    url               => 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $wso2am_db_url = 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE'
+  $wso2am_db_username = 'wso2carbon'
+  $wso2am_db_password = 'wso2carbon'
+  $wso2am_db_driver = 'org.h2.Driver'
 
-  $wso2am_stat_db = {
-    url               =>
-    'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $stat_db_url = 'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE'
+  $stat_db_username = 'wso2carbon'
+  $stat_db_password = 'wso2carbon'
+  $stat_db_driver = 'org.h2.Driver'
 
-  $wso2_mb_store_db = {
-    url               => 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $mb_store_db_url = 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $mb_store_db_username = 'wso2carbon'
+  $mb_store_db_password = 'wso2carbon'
+  $mb_store_driver = 'org.h2.Driver'
 
   # ----- Carbon.xml config params -----
-  $ports = {
-    offset => 0
-  }
+  $ports_offset = 0
 
-  $key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $key_store_type = 'JKS'
+  $key_store_password = 'wso2carbon'
+  $key_store_key_alias = 'wso2carbon'
+  $key_store_key_password = 'wso2carbon'
 
-  $internal_key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $internal_key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $internal_key_store_type = 'JKS'
+  $internal_key_store_password = 'wso2carbon'
+  $internal_key_store_key_alias = 'wso2carbon'
+  $internal_key_store_key_password = 'wso2carbon'
 
-  $trust_store = {
-    location => '${carbon.home}/repository/resources/security/client-truststore.jks',
-    type     => 'JKS',
-    password => 'wso2carbon'
-  }
+  $trust_store = '${carbon.home}/repository/resources/security/client-truststore.jks'
+  $trust_store_type = 'JKS'
+  $trust_store_password = 'wso2carbon'
 }

--- a/modules/apim/templates/carbon-home/repository/conf/api-manager.xml.erb
+++ b/modules/apim/templates/carbon-home/repository/conf/api-manager.xml.erb
@@ -16,14 +16,14 @@
          logic relies on this. -->
     <AuthManager>
         <!-- Server URL of the Authentication service -->
-        <ServerURL><%= @auth_manager['server_url'] %></ServerURL>
+        <ServerURL><%= @auth_manager_url %></ServerURL>
         <!-- Admin username for the Authentication manager. -->
-        <Username><%= @auth_manager['username'] %></Username>
+        <Username><%= @auth_manager_username %></Username>
         <!-- Admin password for the Authentication manager. -->
-        <Password><%= @auth_manager['password'] %></Password>
+        <Password><%= @auth_manager_password %></Password>
         <!-- Indicates whether the permissions checking of the user (on the Publisher and Store) should be done
            via a remote service. The check will be done on the local server when false. -->
-        <CheckPermissionsRemotely><%= @auth_manager['check_permission_remotely'] %></CheckPermissionsRemotely>
+        <CheckPermissionsRemotely><%= @auth_manager_check_permission_remotely %></CheckPermissionsRemotely>
     </AuthManager>
 
     <JWTConfiguration>
@@ -85,15 +85,15 @@
                 <Name>Production and Sandbox</Name>
                 <Description>This is a hybrid gateway that handles both production and sandbox token traffic.</Description>
                 <!-- Server URL of the API gateway -->
-                <ServerURL><%= @api_gateway['server_url'] %></ServerURL>
+                <ServerURL><%= @api_gateway_url %></ServerURL>
 		        <!-- Admin username for the API gateway. -->
-                <Username><%= @api_gateway['username'] %></Username>
+                <Username><%= @api_gateway_username %></Username>
                 <!-- Admin password for the API gateway.-->
-                <Password><%= @api_gateway['password'] %></Password>
+                <Password><%= @api_gateway_password %></Password>
                 <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
-                <GatewayEndpoint><%= @api_gateway['gateway_endpoint'] %></GatewayEndpoint>
+                <GatewayEndpoint><%= @api_gateway_endpoint %></GatewayEndpoint>
                 <!-- Endpoint of the Websocket APIs hosted in this API Gateway -->
-                <GatewayWSEndpoint><%= @api_gateway['gateway_ws_endpoint'] %></GatewayWSEndpoint>
+                <GatewayWSEndpoint><%= @api_gateway_ws_endpoint %></GatewayWSEndpoint>
             </Environment>
         </Environments>
     </APIGateway>
@@ -139,7 +139,7 @@
     -->
     <Analytics>
         <!-- Enable Analytics for API Manager -->
-        <Enabled><%= @analytics['enabled'] %></Enabled>
+        <Enabled><%= @analytics_enable %></Enabled>
 
         <!-- Server URL of the remote StreamProcessor server used to collect statistics. Must
              be specified in protocol://hostname:port/ format.
@@ -151,20 +151,20 @@
 
              Ex - Multiple Receiver Groups with two receivers each
              {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
-        <StreamProcessorServerURL><%= @analytics['sp_server_url'] %></StreamProcessorServerURL>
+        <StreamProcessorServerURL><%= @stream_processor_url %></StreamProcessorServerURL>
         <!--StreamProcessorAuthServerURL>{ssl://localhost:7712}</StreamProcessorAuthServerURL-->
         <!-- Administrator username to login to the remote StreamProcessor server. -->
-        <StreamProcessorUsername><%= @analytics['sp_username'] %></StreamProcessorUsername>
+        <StreamProcessorUsername><%= @stream_processor_username %></StreamProcessorUsername>
         <!-- Administrator password to login to the remote StreamProcessor server. -->
-        <StreamProcessorPassword><%= @analytics['sp_password'] %></StreamProcessorPassword>
+        <StreamProcessorPassword><%= @stream_processor_password %></StreamProcessorPassword>
 
         <!-- For APIM implemented Statistic client for RDBMS -->
         <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRestClientImpl</StatsProviderImpl>
 
         <!-- StreamProcessor REST API configuration -->
-        <StreamProcessorRestApiURL><%= @analytics['sp_restapi_url'] %></StreamProcessorRestApiURL>
-        <StreamProcessorRestApiUsername><%= @analytics['sp_restapi_username'] %></StreamProcessorRestApiUsername>
-        <StreamProcessorRestApiPassword><%= @analytics['sp_restapi_password'] %></StreamProcessorRestApiPassword>
+        <StreamProcessorRestApiURL><%= @stream_processor_restapi_url %></StreamProcessorRestApiURL>
+        <StreamProcessorRestApiUsername><%= @stream_processor_restapi_username %></StreamProcessorRestApiUsername>
+        <StreamProcessorRestApiPassword><%= @stream_processor_restapi_password %></StreamProcessorRestApiPassword>
 
         <!-- Below property is used to skip trying to connect to event receiver nodes when publishing events even if
             the stats enabled flag is set to true. -->
@@ -301,15 +301,15 @@
         <!--This property is used to indicate how we do user name comparision for token generation https://wso2.org/jira/browse/APIMANAGER-2225-->
         <CompareCaseInsensitively>true</CompareCaseInsensitively>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_store['url'] %></URL>
+        <URL><%= @api_store_url %></URL>
 
         <!-- Server URL of the API Store. -->
-        <ServerURL><%= @api_store['server_url'] %></ServerURL>
+        <ServerURL><%= @api_store_server_url %></ServerURL>
         <!-- Admin username for API Store. -->
-        <Username><%= @api_store['username'] %></Username>
+        <Username><%= @api_store_username %></Username>
 
         <!-- Admin password for API Store. -->
-        <Password><%= @api_store['password'] %></Password>
+        <Password><%= @api_store_password %></Password>
         <!-- This parameter specifies whether to display multiple versions of same
              API or only showing the latest version of an API. -->
         <DisplayMultipleVersions>false</DisplayMultipleVersions>
@@ -340,7 +340,7 @@
 
     <APIPublisher>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_publisher['url'] %></URL>
+        <URL><%= @api_publisher_url %></URL>
         <!-- This parameter specifies enabling the capability of setting API documentation level granular visibility levels.
              By default any document associate with an API will have the same permissions set as the API.With enabling below
              property,it will show two additional permission levels as visible only to all registered users in a particular

--- a/modules/apim/templates/carbon-home/repository/conf/carbon.xml.erb
+++ b/modules/apim/templates/carbon-home/repository/conf/carbon.xml.erb
@@ -124,7 +124,7 @@
          the define value + Offset.
          e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
          -->
-        <Offset><%= @ports['offset'] %></Offset>
+        <Offset><%= @ports_offset %></Offset>
 
         <!-- The JMX Ports -->
         <JMX>
@@ -390,15 +390,15 @@
         -->
         <KeyStore>
             <!-- Keystore file location-->
-            <Location><%= @key_store['location'] %></Location>
+            <Location><%= @key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @key_store['type'] %></Type>
+            <Type><%= @key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @key_store['password'] %></Password>
+            <Password><%= @key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @key_store_key_password %></KeyPassword>
         </KeyStore>
 
         <!--
@@ -407,15 +407,15 @@
         -->
         <InternalKeyStore>
             <!-- Keystore file location-->
-            <Location><%= @internal_key_store['location'] %></Location>
+            <Location><%= @internal_key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @internal_key_store['type'] %></Type>
+            <Type><%= @internal_key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @internal_key_store['password'] %></Password>
+            <Password><%= @internal_key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @internal_key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @internal_key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @internal_key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @internal_key_store_key_password %></KeyPassword>
         </InternalKeyStore>
 
         <!--
@@ -424,11 +424,11 @@
         -->
         <TrustStore>
             <!-- trust-store file location -->
-            <Location><%= @trust_store['location'] %></Location>
+            <Location><%= @trust_store %></Location>
             <!-- trust-store type (JKS/PKCS12 etc.) -->
-            <Type><%= @trust_store['type'] %></Type>
+            <Type><%= @trust_store_type %></Type>
             <!-- trust-store password -->
-            <Password><%= @trust_store['password'] %></Password>
+            <Password><%= @trust_store_password %></Password>
         </TrustStore>
 
         <!--

--- a/modules/apim/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
+++ b/modules/apim/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
@@ -36,11 +36,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_db['url'] %></url>
-                    <username><%= @wso2am_db['username'] %></username>
-                    <password><%= @wso2am_db['password'] %></password>
+                    <url><%= @wso2am_db_url %></url>
+                    <username><%= @wso2am_db_username %></username>
+                    <password><%= @wso2am_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @wso2am_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -58,11 +58,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_stat_db['url'] %></url>
-                    <username><%= @wso2am_stat_db['username'] %></username>
-                    <password><%= @wso2am_stat_db['password'] %></password>
+                    <url><%= @stat_db_url %></url>
+                    <username><%= @stat_db_username %></username>
+                    <password><%= @stat_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_stat_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @stat_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -80,10 +80,10 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2_mb_store_db['url'] %></url>
-                    <username><%= @wso2_mb_store_db['username'] %></username>
-                    <password><%= @wso2_mb_store_db['password'] %></password>
-                    <driverClassName><%= @wso2_mb_store_db['driver_class_name'] %></driverClassName>
+                    <url><%= @mb_store_db_url %></url>
+                    <username><%= @mb_store_db_username %></username>
+                    <password><%= @mb_store_db_password %></password>
+                    <driverClassName><%= @mb_store_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>

--- a/modules/apim_analytics_dashboard/manifests/init.pp
+++ b/modules/apim_analytics_dashboard/manifests/init.pp
@@ -19,14 +19,16 @@
 class apim_analytics_dashboard inherits apim_analytics_dashboard::params {
 
   if $::osfamily == 'redhat' {
-    $apim_analytics_package = 'wso2am-analytics-linux-installer-x64-2.6.0.rpm'
-    $installer_provider = 'rpm'
-    $install_path = '/usr/lib64/wso2/wso2am-analytics/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
+    $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $apim_analytics_package = 'wso2am-analytics-linux-installer-x64-2.6.0.deb'
-    $installer_provider = 'dpkg'
-    $install_path = '/usr/lib/wso2/wso2am-analytics/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
+    $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -52,18 +54,18 @@ class apim_analytics_dashboard inherits apim_analytics_dashboard::params {
   }
 
   # Copy the installer to the directory
-  file { "/opt/${product}/${apim_analytics_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${apim_analytics_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
-  # Install WSO2 API Manager
-  package { $product:
+  # Install WSO2 API Manager Analytics
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${apim_analytics_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/apim_analytics_dashboard/manifests/params.pp
+++ b/modules/apim_analytics_dashboard/manifests/params.pp
@@ -23,6 +23,7 @@ class apim_analytics_dashboard::params {
   $user_home = '/home/$user'
   $user_group_id = 802
   $product = 'wso2am-analytics'
+  $product_version = '2.6.0'
   $profile = 'dashboard'
   $service_name = "${product}-${profile}"
   $hostname = 'localhost'

--- a/modules/apim_analytics_worker/manifests/init.pp
+++ b/modules/apim_analytics_worker/manifests/init.pp
@@ -19,14 +19,16 @@
 class apim_analytics_worker inherits apim_analytics_worker::params {
 
   if $::osfamily == 'redhat' {
-    $apim_analytics_package = 'wso2am-analytics-linux-installer-x64-2.6.0.rpm'
-    $installer_provider = 'rpm'
-    $install_path = '/usr/lib64/wso2/wso2am-analytics/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
+    $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $apim_analytics_package = 'wso2am-analytics-linux-installer-x64-2.6.0.deb'
-    $installer_provider = 'dpkg'
-    $install_path = '/usr/lib/wso2/wso2am-analytics/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
+    $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -59,11 +61,11 @@ class apim_analytics_worker inherits apim_analytics_worker::params {
     source => "puppet:///modules/${module_name}/${apim_analytics_package}",
   }
 
-  # Install WSO2 API Manager
-  package { $product:
+  # Install WSO2 API Manager Analytics
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${product}/${apim_analytics_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/apim_analytics_worker/manifests/params.pp
+++ b/modules/apim_analytics_worker/manifests/params.pp
@@ -23,6 +23,7 @@ class apim_analytics_worker::params {
   $user_home = '/home/$user'
   $user_group_id = 802
   $product = 'wso2am-analytics'
+  $product_version = '2.6.0'
   $profile = 'worker'
   $service_name = "${product}-${profile}"
   $hostname = 'localhost'

--- a/modules/apim_gateway/manifests/init.pp
+++ b/modules/apim_gateway/manifests/init.pp
@@ -19,14 +19,16 @@
 class apim_gateway inherits apim_gateway::params {
 
   if $::osfamily == 'redhat' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.rpm'
-    $installer_provider = 'rpm'
-    $install_path = '/usr/lib64/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
+    $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.deb'
-    $installer_provider = 'dpkg'
-    $install_path = '/usr/lib/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
+    $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -45,25 +47,25 @@ class apim_gateway inherits apim_gateway::params {
     system => true,
   }
   # Ensure the installation directory is available
-  file { "/opt/${service_name}":
+  file { "/opt/${product}":
     ensure => 'directory',
     owner  => $user,
     group  => $user_group,
   }
 
   # Copy the installer to the directory
-  file { "/opt/${service_name}/${apim_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${apim_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 API Manager
-  package { $service_name:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${service_name}/${apim_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/apim_gateway/manifests/params.pp
+++ b/modules/apim_gateway/manifests/params.pp
@@ -22,7 +22,10 @@ class apim_gateway::params {
   $user_group = 'wso2'
   $user_home = '/home/$user'
   $user_group_id = 802
+  $product = 'wso2am'
+  $product_version = '2.6.0'
   $service_name = 'wso2am'
+
   $hostname = 'localhost'
   $mgt_hostname = 'localhost'
   $jdk_version = 'jdk1.8.0_192'
@@ -41,91 +44,65 @@ class apim_gateway::params {
     # 'repository/conf/tomcat/catalina-server.xml',
   ]
 
-
   # ----- api-manager.xml config params -----
-  $auth_manager = {
-    server_url                => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username                  => '${admin.username}',
-    password                  => '${admin.password}',
-    check_permission_remotely => 'false'
-  }
+  $auth_manager_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $auth_manager_username = '${admin.username}'
+  $auth_manager_password = '${admin.password}'
+  $auth_manager_check_permission_remotely = 'false'
 
-  $api_gateway = {
-    server_url          => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username            => '${admin.username}',
-    password            => '${admin.password}',
-    gateway_endpoint    => 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}',
-    gateway_ws_endpoint => 'ws://${carbon.local.ip}:9099'
-  }
+  $api_gateway_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_gateway_username = '${admin.username}'
+  $api_gateway_password = '${admin.password}'
+  $api_gateway_endpoint = 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}'
+  $api_gateway_ws_endpoint = 'ws://${carbon.local.ip}:9099'
 
-  $analytics = {
-    enable              => 'false',
-    sp_server_url       => '{tcp://localhost:7612}',
-    sp_username         => '${admin.username}',
-    sp_password         => '${admin.password}',
-    sp_restapi_url      => 'https://localhost:7444',
-    sp_restapi_username => '${admin.username}',
-    sp_restapi_password => '${admin.password}'
-  }
+  $analytics_enable = 'false'
+  $stream_processor_url = '{tcp://localhost:7612}'
+  $stream_processor_username = '${admin.username}'
+  $stream_processor_password = '${admin.password}'
+  $stream_processor_restapi_url = 'https://localhost:7444'
+  $stream_processor_restapi_username = '${admin.username}'
+  $stream_processor_restapi_password = '${admin.password}'
 
-  $api_store = {
-    url        => 'https://localhost:${mgt.transport.https.port}/store',
-    server_url => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username   => '${admin.username}',
-    password   => '${admin.password}'
-  }
+  $api_store_url = 'https://localhost:${mgt.transport.https.port}/store'
+  $api_store_server_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_store_username = '${admin.username}'
+  $api_store_password = '${admin.password}'
 
-  $api_publisher = {
-    url => 'https://localhost:${mgt.transport.https.port}/publisher'
-  }
+  $api_publisher_url = 'https://localhost:${mgt.transport.https.port}/publisher'
 
   # ----- Master-datasources config params -----
-  $wso2am_db = {
-    url               => 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $wso2am_db_url = 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE'
+  $wso2am_db_username = 'wso2carbon'
+  $wso2am_db_password = 'wso2carbon'
+  $wso2am_db_driver = 'org.h2.Driver'
 
-  $wso2am_stat_db = {
-    url               =>
-    'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $stat_db_url = 'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE'
+  $stat_db_username = 'wso2carbon'
+  $stat_db_password = 'wso2carbon'
+  $stat_db_driver = 'org.h2.Driver'
 
-  $wso2_mb_store_db = {
-    url               => 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $mb_store_db_url = 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $mb_store_db_username = 'wso2carbon'
+  $mb_store_db_password = 'wso2carbon'
+  $mb_store_driver = 'org.h2.Driver'
 
   # ----- Carbon.xml config params -----
-  $ports = {
-    offset => 0
-  }
+  $ports_offset = 0
 
-  $key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $key_store_type = 'JKS'
+  $key_store_password = 'wso2carbon'
+  $key_store_key_alias = 'wso2carbon'
+  $key_store_key_password = 'wso2carbon'
 
-  $internal_key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $internal_key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $internal_key_store_type = 'JKS'
+  $internal_key_store_password = 'wso2carbon'
+  $internal_key_store_key_alias = 'wso2carbon'
+  $internal_key_store_key_password = 'wso2carbon'
 
-  $trust_store = {
-    location => '${carbon.home}/repository/resources/security/client-truststore.jks',
-    type     => 'JKS',
-    password => 'wso2carbon'
-  }
+  $trust_store = '${carbon.home}/repository/resources/security/client-truststore.jks'
+  $trust_store_type = 'JKS'
+  $trust_store_password = 'wso2carbon'
 }

--- a/modules/apim_gateway/manifests/startserver.pp
+++ b/modules/apim_gateway/manifests/startserver.pp
@@ -16,10 +16,7 @@
 
 # Class apim::startserver
 # Starts the server as a service in the final stage.
-class apim_gateway::startserver (
-  $service_name = $apim_gateway::params::service_name
-)
-  inherits apim_gateway::params {
+class apim_gateway::startserver inherits apim_gateway::params {
 
   service { $service_name:
     ensure => running,

--- a/modules/apim_gateway/templates/carbon-home/repository/conf/api-manager.xml.erb
+++ b/modules/apim_gateway/templates/carbon-home/repository/conf/api-manager.xml.erb
@@ -16,14 +16,14 @@
          logic relies on this. -->
     <AuthManager>
         <!-- Server URL of the Authentication service -->
-        <ServerURL><%= @auth_manager['server_url'] %></ServerURL>
+        <ServerURL><%= @auth_manager_url %></ServerURL>
         <!-- Admin username for the Authentication manager. -->
-        <Username><%= @auth_manager['username'] %></Username>
+        <Username><%= @auth_manager_username %></Username>
         <!-- Admin password for the Authentication manager. -->
-        <Password><%= @auth_manager['password'] %></Password>
+        <Password><%= @auth_manager_password %></Password>
         <!-- Indicates whether the permissions checking of the user (on the Publisher and Store) should be done
            via a remote service. The check will be done on the local server when false. -->
-        <CheckPermissionsRemotely><%= @auth_manager['check_permission_remotely'] %></CheckPermissionsRemotely>
+        <CheckPermissionsRemotely><%= @auth_manager_check_permission_remotely %></CheckPermissionsRemotely>
     </AuthManager>
 
     <JWTConfiguration>
@@ -85,15 +85,15 @@
                 <Name>Production and Sandbox</Name>
                 <Description>This is a hybrid gateway that handles both production and sandbox token traffic.</Description>
                 <!-- Server URL of the API gateway -->
-                <ServerURL><%= @api_gateway['server_url'] %></ServerURL>
+                <ServerURL><%= @api_gateway_url %></ServerURL>
 		        <!-- Admin username for the API gateway. -->
-                <Username><%= @api_gateway['username'] %></Username>
+                <Username><%= @api_gateway_username %></Username>
                 <!-- Admin password for the API gateway.-->
-                <Password><%= @api_gateway['password'] %></Password>
+                <Password><%= @api_gateway_password %></Password>
                 <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
-                <GatewayEndpoint><%= @api_gateway['gateway_endpoint'] %></GatewayEndpoint>
+                <GatewayEndpoint><%= @api_gateway_endpoint %></GatewayEndpoint>
                 <!-- Endpoint of the Websocket APIs hosted in this API Gateway -->
-                <GatewayWSEndpoint><%= @api_gateway['gateway_ws_endpoint'] %></GatewayWSEndpoint>
+                <GatewayWSEndpoint><%= @api_gateway_ws_endpoint %></GatewayWSEndpoint>
             </Environment>
         </Environments>
     </APIGateway>
@@ -139,7 +139,7 @@
     -->
     <Analytics>
         <!-- Enable Analytics for API Manager -->
-        <Enabled><%= @analytics['enabled'] %></Enabled>
+        <Enabled><%= @analytics_enable %></Enabled>
 
         <!-- Server URL of the remote StreamProcessor server used to collect statistics. Must
              be specified in protocol://hostname:port/ format.
@@ -151,20 +151,20 @@
 
              Ex - Multiple Receiver Groups with two receivers each
              {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
-        <StreamProcessorServerURL><%= @analytics['sp_server_url'] %></StreamProcessorServerURL>
+        <StreamProcessorServerURL><%= @stream_processor_url %></StreamProcessorServerURL>
         <!--StreamProcessorAuthServerURL>{ssl://localhost:7712}</StreamProcessorAuthServerURL-->
         <!-- Administrator username to login to the remote StreamProcessor server. -->
-        <StreamProcessorUsername><%= @analytics['sp_username'] %></StreamProcessorUsername>
+        <StreamProcessorUsername><%= @stream_processor_username %></StreamProcessorUsername>
         <!-- Administrator password to login to the remote StreamProcessor server. -->
-        <StreamProcessorPassword><%= @analytics['sp_password'] %></StreamProcessorPassword>
+        <StreamProcessorPassword><%= @stream_processor_password %></StreamProcessorPassword>
 
         <!-- For APIM implemented Statistic client for RDBMS -->
         <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRestClientImpl</StatsProviderImpl>
 
         <!-- StreamProcessor REST API configuration -->
-        <StreamProcessorRestApiURL><%= @analytics['sp_restapi_url'] %></StreamProcessorRestApiURL>
-        <StreamProcessorRestApiUsername><%= @analytics['sp_restapi_username'] %></StreamProcessorRestApiUsername>
-        <StreamProcessorRestApiPassword><%= @analytics['sp_restapi_password'] %></StreamProcessorRestApiPassword>
+        <StreamProcessorRestApiURL><%= @stream_processor_restapi_url %></StreamProcessorRestApiURL>
+        <StreamProcessorRestApiUsername><%= @stream_processor_restapi_username %></StreamProcessorRestApiUsername>
+        <StreamProcessorRestApiPassword><%= @stream_processor_restapi_password %></StreamProcessorRestApiPassword>
 
         <!-- Below property is used to skip trying to connect to event receiver nodes when publishing events even if
             the stats enabled flag is set to true. -->
@@ -301,15 +301,15 @@
         <!--This property is used to indicate how we do user name comparision for token generation https://wso2.org/jira/browse/APIMANAGER-2225-->
         <CompareCaseInsensitively>true</CompareCaseInsensitively>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_store['url'] %></URL>
+        <URL><%= @api_store_url %></URL>
 
         <!-- Server URL of the API Store. -->
-        <ServerURL><%= @api_store['server_url'] %></ServerURL>
+        <ServerURL><%= @api_store_server_url %></ServerURL>
         <!-- Admin username for API Store. -->
-        <Username><%= @api_store['username'] %></Username>
+        <Username><%= @api_store_username %></Username>
 
         <!-- Admin password for API Store. -->
-        <Password><%= @api_store['password'] %></Password>
+        <Password><%= @api_store_password %></Password>
         <!-- This parameter specifies whether to display multiple versions of same
              API or only showing the latest version of an API. -->
         <DisplayMultipleVersions>false</DisplayMultipleVersions>
@@ -340,7 +340,7 @@
 
     <APIPublisher>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_publisher['url'] %></URL>
+        <URL><%= @api_publisher_url %></URL>
         <!-- This parameter specifies enabling the capability of setting API documentation level granular visibility levels.
              By default any document associate with an API will have the same permissions set as the API.With enabling below
              property,it will show two additional permission levels as visible only to all registered users in a particular

--- a/modules/apim_gateway/templates/carbon-home/repository/conf/carbon.xml.erb
+++ b/modules/apim_gateway/templates/carbon-home/repository/conf/carbon.xml.erb
@@ -124,7 +124,7 @@
          the define value + Offset.
          e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
          -->
-        <Offset><%= @ports['offset'] %></Offset>
+        <Offset><%= @ports_offset %></Offset>
 
         <!-- The JMX Ports -->
         <JMX>
@@ -390,15 +390,15 @@
         -->
         <KeyStore>
             <!-- Keystore file location-->
-            <Location><%= @key_store['location'] %></Location>
+            <Location><%= @key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @key_store['type'] %></Type>
+            <Type><%= @key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @key_store['password'] %></Password>
+            <Password><%= @key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @key_store_key_password %></KeyPassword>
         </KeyStore>
 
         <!--
@@ -407,15 +407,15 @@
         -->
         <InternalKeyStore>
             <!-- Keystore file location-->
-            <Location><%= @internal_key_store['location'] %></Location>
+            <Location><%= @internal_key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @internal_key_store['type'] %></Type>
+            <Type><%= @internal_key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @internal_key_store['password'] %></Password>
+            <Password><%= @internal_key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @internal_key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @internal_key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @internal_key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @internal_key_store_key_password %></KeyPassword>
         </InternalKeyStore>
 
         <!--
@@ -424,11 +424,11 @@
         -->
         <TrustStore>
             <!-- trust-store file location -->
-            <Location><%= @trust_store['location'] %></Location>
+            <Location><%= @trust_store %></Location>
             <!-- trust-store type (JKS/PKCS12 etc.) -->
-            <Type><%= @trust_store['type'] %></Type>
+            <Type><%= @trust_store_type %></Type>
             <!-- trust-store password -->
-            <Password><%= @trust_store['password'] %></Password>
+            <Password><%= @trust_store_password %></Password>
         </TrustStore>
 
         <!--

--- a/modules/apim_gateway/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
+++ b/modules/apim_gateway/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
@@ -36,11 +36,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_db['url'] %></url>
-                    <username><%= @wso2am_db['username'] %></username>
-                    <password><%= @wso2am_db['password'] %></password>
+                    <url><%= @wso2am_db_url %></url>
+                    <username><%= @wso2am_db_username %></username>
+                    <password><%= @wso2am_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @wso2am_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -58,11 +58,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_stat_db['url'] %></url>
-                    <username><%= @wso2am_stat_db['username'] %></username>
-                    <password><%= @wso2am_stat_db['password'] %></password>
+                    <url><%= @stat_db_url %></url>
+                    <username><%= @stat_db_username %></username>
+                    <password><%= @stat_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_stat_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @stat_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -80,10 +80,10 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2_mb_store_db['url'] %></url>
-                    <username><%= @wso2_mb_store_db['username'] %></username>
-                    <password><%= @wso2_mb_store_db['password'] %></password>
-                    <driverClassName><%= @wso2_mb_store_db['driver_class_name'] %></driverClassName>
+                    <url><%= @mb_store_db_url %></url>
+                    <username><%= @mb_store_db_username %></username>
+                    <password><%= @mb_store_db_password %></password>
+                    <driverClassName><%= @mb_store_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>

--- a/modules/apim_km/manifests/init.pp
+++ b/modules/apim_km/manifests/init.pp
@@ -19,14 +19,16 @@
 class apim_km inherits apim_km::params {
 
   if $::osfamily == 'redhat' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.rpm'
-    $installer_provider = 'rpm'
-    $install_path = '/usr/lib64/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
+    $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.deb'
-    $installer_provider = 'dpkg'
-    $install_path = '/usr/lib/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
+    $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -45,25 +47,25 @@ class apim_km inherits apim_km::params {
     system => true,
   }
   # Ensure the installation directory is available
-  file { "/opt/${service_name}":
+  file { "/opt/${product}":
     ensure => 'directory',
     owner  => $user,
     group  => $user_group,
   }
 
   # Copy the installer to the directory
-  file { "/opt/${service_name}/${apim_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${apim_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 API Manager
-  package { $service_name:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${service_name}/${apim_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/apim_km/manifests/params.pp
+++ b/modules/apim_km/manifests/params.pp
@@ -22,7 +22,10 @@ class apim_km::params {
   $user_group = 'wso2'
   $user_home = '/home/$user'
   $user_group_id = 802
+  $product = 'wso2am'
+  $product_version = '2.6.0'
   $service_name = 'wso2am'
+
   $hostname = 'localhost'
   $mgt_hostname = 'localhost'
   $jdk_version = 'jdk1.8.0_192'
@@ -41,91 +44,65 @@ class apim_km::params {
     # 'repository/conf/tomcat/catalina-server.xml',
   ]
 
-
   # ----- api-manager.xml config params -----
-  $auth_manager = {
-    server_url                => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username                  => '${admin.username}',
-    password                  => '${admin.password}',
-    check_permission_remotely => 'false'
-  }
+  $auth_manager_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $auth_manager_username = '${admin.username}'
+  $auth_manager_password = '${admin.password}'
+  $auth_manager_check_permission_remotely = 'false'
 
-  $api_gateway = {
-    server_url          => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username            => '${admin.username}',
-    password            => '${admin.password}',
-    gateway_endpoint    => 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}',
-    gateway_ws_endpoint => 'ws://${carbon.local.ip}:9099'
-  }
+  $api_gateway_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_gateway_username = '${admin.username}'
+  $api_gateway_password = '${admin.password}'
+  $api_gateway_endpoint = 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}'
+  $api_gateway_ws_endpoint = 'ws://${carbon.local.ip}:9099'
 
-  $analytics = {
-    enable              => 'false',
-    sp_server_url       => '{tcp://localhost:7612}',
-    sp_username         => '${admin.username}',
-    sp_password         => '${admin.password}',
-    sp_restapi_url      => 'https://localhost:7444',
-    sp_restapi_username => '${admin.username}',
-    sp_restapi_password => '${admin.password}'
-  }
+  $analytics_enable = 'false'
+  $stream_processor_url = '{tcp://localhost:7612}'
+  $stream_processor_username = '${admin.username}'
+  $stream_processor_password = '${admin.password}'
+  $stream_processor_restapi_url = 'https://localhost:7444'
+  $stream_processor_restapi_username = '${admin.username}'
+  $stream_processor_restapi_password = '${admin.password}'
 
-  $api_store = {
-    url        => 'https://localhost:${mgt.transport.https.port}/store',
-    server_url => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username   => '${admin.username}',
-    password   => '${admin.password}'
-  }
+  $api_store_url = 'https://localhost:${mgt.transport.https.port}/store'
+  $api_store_server_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_store_username = '${admin.username}'
+  $api_store_password = '${admin.password}'
 
-  $api_publisher = {
-    url => 'https://localhost:${mgt.transport.https.port}/publisher'
-  }
+  $api_publisher_url = 'https://localhost:${mgt.transport.https.port}/publisher'
 
   # ----- Master-datasources config params -----
-  $wso2am_db = {
-    url               => 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $wso2am_db_url = 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE'
+  $wso2am_db_username = 'wso2carbon'
+  $wso2am_db_password = 'wso2carbon'
+  $wso2am_db_driver = 'org.h2.Driver'
 
-  $wso2am_stat_db = {
-    url               =>
-    'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $stat_db_url = 'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE'
+  $stat_db_username = 'wso2carbon'
+  $stat_db_password = 'wso2carbon'
+  $stat_db_driver = 'org.h2.Driver'
 
-  $wso2_mb_store_db = {
-    url               => 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $mb_store_db_url = 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $mb_store_db_username = 'wso2carbon'
+  $mb_store_db_password = 'wso2carbon'
+  $mb_store_driver = 'org.h2.Driver'
 
   # ----- Carbon.xml config params -----
-  $ports = {
-    offset => 0
-  }
+  $ports_offset = 0
 
-  $key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $key_store_type = 'JKS'
+  $key_store_password = 'wso2carbon'
+  $key_store_key_alias = 'wso2carbon'
+  $key_store_key_password = 'wso2carbon'
 
-  $internal_key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $internal_key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $internal_key_store_type = 'JKS'
+  $internal_key_store_password = 'wso2carbon'
+  $internal_key_store_key_alias = 'wso2carbon'
+  $internal_key_store_key_password = 'wso2carbon'
 
-  $trust_store = {
-    location => '${carbon.home}/repository/resources/security/client-truststore.jks',
-    type     => 'JKS',
-    password => 'wso2carbon'
-  }
+  $trust_store = '${carbon.home}/repository/resources/security/client-truststore.jks'
+  $trust_store_type = 'JKS'
+  $trust_store_password = 'wso2carbon'
 }

--- a/modules/apim_km/manifests/startserver.pp
+++ b/modules/apim_km/manifests/startserver.pp
@@ -16,10 +16,7 @@
 
 # Class apim::startserver
 # Starts the server as a service in the final stage.
-class apim_km::startserver (
-  $service_name = $apim_km::params::service_name
-)
-  inherits apim_km::params {
+class apim_km::startserver inherits apim_km::params {
 
   service { $service_name:
     ensure => running,

--- a/modules/apim_km/templates/carbon-home/repository/conf/api-manager.xml.erb
+++ b/modules/apim_km/templates/carbon-home/repository/conf/api-manager.xml.erb
@@ -16,14 +16,14 @@
          logic relies on this. -->
     <AuthManager>
         <!-- Server URL of the Authentication service -->
-        <ServerURL><%= @auth_manager['server_url'] %></ServerURL>
+        <ServerURL><%= @auth_manager_url %></ServerURL>
         <!-- Admin username for the Authentication manager. -->
-        <Username><%= @auth_manager['username'] %></Username>
+        <Username><%= @auth_manager_username %></Username>
         <!-- Admin password for the Authentication manager. -->
-        <Password><%= @auth_manager['password'] %></Password>
+        <Password><%= @auth_manager_password %></Password>
         <!-- Indicates whether the permissions checking of the user (on the Publisher and Store) should be done
            via a remote service. The check will be done on the local server when false. -->
-        <CheckPermissionsRemotely><%= @auth_manager['check_permission_remotely'] %></CheckPermissionsRemotely>
+        <CheckPermissionsRemotely><%= @auth_manager_check_permission_remotely %></CheckPermissionsRemotely>
     </AuthManager>
 
     <JWTConfiguration>
@@ -85,15 +85,15 @@
                 <Name>Production and Sandbox</Name>
                 <Description>This is a hybrid gateway that handles both production and sandbox token traffic.</Description>
                 <!-- Server URL of the API gateway -->
-                <ServerURL><%= @api_gateway['server_url'] %></ServerURL>
+                <ServerURL><%= @api_gateway_url %></ServerURL>
 		        <!-- Admin username for the API gateway. -->
-                <Username><%= @api_gateway['username'] %></Username>
+                <Username><%= @api_gateway_username %></Username>
                 <!-- Admin password for the API gateway.-->
-                <Password><%= @api_gateway['password'] %></Password>
+                <Password><%= @api_gateway_password %></Password>
                 <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
-                <GatewayEndpoint><%= @api_gateway['gateway_endpoint'] %></GatewayEndpoint>
+                <GatewayEndpoint><%= @api_gateway_endpoint %></GatewayEndpoint>
                 <!-- Endpoint of the Websocket APIs hosted in this API Gateway -->
-                <GatewayWSEndpoint><%= @api_gateway['gateway_ws_endpoint'] %></GatewayWSEndpoint>
+                <GatewayWSEndpoint><%= @api_gateway_ws_endpoint %></GatewayWSEndpoint>
             </Environment>
         </Environments>
     </APIGateway>
@@ -139,7 +139,7 @@
     -->
     <Analytics>
         <!-- Enable Analytics for API Manager -->
-        <Enabled><%= @analytics['enabled'] %></Enabled>
+        <Enabled><%= @analytics_enable %></Enabled>
 
         <!-- Server URL of the remote StreamProcessor server used to collect statistics. Must
              be specified in protocol://hostname:port/ format.
@@ -151,20 +151,20 @@
 
              Ex - Multiple Receiver Groups with two receivers each
              {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
-        <StreamProcessorServerURL><%= @analytics['sp_server_url'] %></StreamProcessorServerURL>
+        <StreamProcessorServerURL><%= @stream_processor_url %></StreamProcessorServerURL>
         <!--StreamProcessorAuthServerURL>{ssl://localhost:7712}</StreamProcessorAuthServerURL-->
         <!-- Administrator username to login to the remote StreamProcessor server. -->
-        <StreamProcessorUsername><%= @analytics['sp_username'] %></StreamProcessorUsername>
+        <StreamProcessorUsername><%= @stream_processor_username %></StreamProcessorUsername>
         <!-- Administrator password to login to the remote StreamProcessor server. -->
-        <StreamProcessorPassword><%= @analytics['sp_password'] %></StreamProcessorPassword>
+        <StreamProcessorPassword><%= @stream_processor_password %></StreamProcessorPassword>
 
         <!-- For APIM implemented Statistic client for RDBMS -->
         <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRestClientImpl</StatsProviderImpl>
 
         <!-- StreamProcessor REST API configuration -->
-        <StreamProcessorRestApiURL><%= @analytics['sp_restapi_url'] %></StreamProcessorRestApiURL>
-        <StreamProcessorRestApiUsername><%= @analytics['sp_restapi_username'] %></StreamProcessorRestApiUsername>
-        <StreamProcessorRestApiPassword><%= @analytics['sp_restapi_password'] %></StreamProcessorRestApiPassword>
+        <StreamProcessorRestApiURL><%= @stream_processor_restapi_url %></StreamProcessorRestApiURL>
+        <StreamProcessorRestApiUsername><%= @stream_processor_restapi_username %></StreamProcessorRestApiUsername>
+        <StreamProcessorRestApiPassword><%= @stream_processor_restapi_password %></StreamProcessorRestApiPassword>
 
         <!-- Below property is used to skip trying to connect to event receiver nodes when publishing events even if
             the stats enabled flag is set to true. -->
@@ -301,15 +301,15 @@
         <!--This property is used to indicate how we do user name comparision for token generation https://wso2.org/jira/browse/APIMANAGER-2225-->
         <CompareCaseInsensitively>true</CompareCaseInsensitively>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_store['url'] %></URL>
+        <URL><%= @api_store_url %></URL>
 
         <!-- Server URL of the API Store. -->
-        <ServerURL><%= @api_store['server_url'] %></ServerURL>
+        <ServerURL><%= @api_store_server_url %></ServerURL>
         <!-- Admin username for API Store. -->
-        <Username><%= @api_store['username'] %></Username>
+        <Username><%= @api_store_username %></Username>
 
         <!-- Admin password for API Store. -->
-        <Password><%= @api_store['password'] %></Password>
+        <Password><%= @api_store_password %></Password>
         <!-- This parameter specifies whether to display multiple versions of same
              API or only showing the latest version of an API. -->
         <DisplayMultipleVersions>false</DisplayMultipleVersions>
@@ -340,7 +340,7 @@
 
     <APIPublisher>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_publisher['url'] %></URL>
+        <URL><%= @api_publisher_url %></URL>
         <!-- This parameter specifies enabling the capability of setting API documentation level granular visibility levels.
              By default any document associate with an API will have the same permissions set as the API.With enabling below
              property,it will show two additional permission levels as visible only to all registered users in a particular

--- a/modules/apim_km/templates/carbon-home/repository/conf/carbon.xml.erb
+++ b/modules/apim_km/templates/carbon-home/repository/conf/carbon.xml.erb
@@ -124,7 +124,7 @@
          the define value + Offset.
          e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
          -->
-        <Offset><%= @ports['offset'] %></Offset>
+        <Offset><%= @ports_offset %></Offset>
 
         <!-- The JMX Ports -->
         <JMX>
@@ -390,15 +390,15 @@
         -->
         <KeyStore>
             <!-- Keystore file location-->
-            <Location><%= @key_store['location'] %></Location>
+            <Location><%= @key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @key_store['type'] %></Type>
+            <Type><%= @key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @key_store['password'] %></Password>
+            <Password><%= @key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @key_store_key_password %></KeyPassword>
         </KeyStore>
 
         <!--
@@ -407,15 +407,15 @@
         -->
         <InternalKeyStore>
             <!-- Keystore file location-->
-            <Location><%= @internal_key_store['location'] %></Location>
+            <Location><%= @internal_key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @internal_key_store['type'] %></Type>
+            <Type><%= @internal_key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @internal_key_store['password'] %></Password>
+            <Password><%= @internal_key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @internal_key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @internal_key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @internal_key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @internal_key_store_key_password %></KeyPassword>
         </InternalKeyStore>
 
         <!--
@@ -424,11 +424,11 @@
         -->
         <TrustStore>
             <!-- trust-store file location -->
-            <Location><%= @trust_store['location'] %></Location>
+            <Location><%= @trust_store %></Location>
             <!-- trust-store type (JKS/PKCS12 etc.) -->
-            <Type><%= @trust_store['type'] %></Type>
+            <Type><%= @trust_store_type %></Type>
             <!-- trust-store password -->
-            <Password><%= @trust_store['password'] %></Password>
+            <Password><%= @trust_store_password %></Password>
         </TrustStore>
 
         <!--

--- a/modules/apim_km/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
+++ b/modules/apim_km/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
@@ -36,11 +36,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_db['url'] %></url>
-                    <username><%= @wso2am_db['username'] %></username>
-                    <password><%= @wso2am_db['password'] %></password>
+                    <url><%= @wso2am_db_url %></url>
+                    <username><%= @wso2am_db_username %></username>
+                    <password><%= @wso2am_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @wso2am_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -58,11 +58,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_stat_db['url'] %></url>
-                    <username><%= @wso2am_stat_db['username'] %></username>
-                    <password><%= @wso2am_stat_db['password'] %></password>
+                    <url><%= @stat_db_url %></url>
+                    <username><%= @stat_db_username %></username>
+                    <password><%= @stat_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_stat_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @stat_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -80,10 +80,10 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2_mb_store_db['url'] %></url>
-                    <username><%= @wso2_mb_store_db['username'] %></username>
-                    <password><%= @wso2_mb_store_db['password'] %></password>
-                    <driverClassName><%= @wso2_mb_store_db['driver_class_name'] %></driverClassName>
+                    <url><%= @mb_store_db_url %></url>
+                    <username><%= @mb_store_db_username %></username>
+                    <password><%= @mb_store_db_password %></password>
+                    <driverClassName><%= @mb_store_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>

--- a/modules/apim_publisher/manifests/init.pp
+++ b/modules/apim_publisher/manifests/init.pp
@@ -19,14 +19,16 @@
 class apim_publisher inherits apim_publisher::params {
 
   if $::osfamily == 'redhat' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.rpm'
-    $installer_provider = 'rpm'
-    $install_path = '/usr/lib64/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
+    $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.deb'
-    $installer_provider = 'dpkg'
-    $install_path = '/usr/lib/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
+    $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -45,25 +47,25 @@ class apim_publisher inherits apim_publisher::params {
     system => true,
   }
   # Ensure the installation directory is available
-  file { "/opt/${service_name}":
+  file { "/opt/${product}":
     ensure => 'directory',
     owner  => $user,
     group  => $user_group,
   }
 
   # Copy the installer to the directory
-  file { "/opt/${service_name}/${apim_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${apim_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 API Manager
-  package { $service_name:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${service_name}/${apim_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/apim_publisher/manifests/params.pp
+++ b/modules/apim_publisher/manifests/params.pp
@@ -22,7 +22,10 @@ class apim_publisher::params {
   $user_group = 'wso2'
   $user_home = '/home/$user'
   $user_group_id = 802
+  $product = 'wso2am'
+  $product_version = '2.6.0'
   $service_name = 'wso2am'
+
   $hostname = 'localhost'
   $mgt_hostname = 'localhost'
   $jdk_version = 'jdk1.8.0_192'
@@ -41,91 +44,65 @@ class apim_publisher::params {
     # 'repository/conf/tomcat/catalina-server.xml',
   ]
 
-
   # ----- api-manager.xml config params -----
-  $auth_manager = {
-    server_url                => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username                  => '${admin.username}',
-    password                  => '${admin.password}',
-    check_permission_remotely => 'false'
-  }
+  $auth_manager_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $auth_manager_username = '${admin.username}'
+  $auth_manager_password = '${admin.password}'
+  $auth_manager_check_permission_remotely = 'false'
 
-  $api_gateway = {
-    server_url          => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username            => '${admin.username}',
-    password            => '${admin.password}',
-    gateway_endpoint    => 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}',
-    gateway_ws_endpoint => 'ws://${carbon.local.ip}:9099'
-  }
+  $api_gateway_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_gateway_username = '${admin.username}'
+  $api_gateway_password = '${admin.password}'
+  $api_gateway_endpoint = 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}'
+  $api_gateway_ws_endpoint = 'ws://${carbon.local.ip}:9099'
 
-  $analytics = {
-    enable              => 'false',
-    sp_server_url       => '{tcp://localhost:7612}',
-    sp_username         => '${admin.username}',
-    sp_password         => '${admin.password}',
-    sp_restapi_url      => 'https://localhost:7444',
-    sp_restapi_username => '${admin.username}',
-    sp_restapi_password => '${admin.password}'
-  }
+  $analytics_enable = 'false'
+  $stream_processor_url = '{tcp://localhost:7612}'
+  $stream_processor_username = '${admin.username}'
+  $stream_processor_password = '${admin.password}'
+  $stream_processor_restapi_url = 'https://localhost:7444'
+  $stream_processor_restapi_username = '${admin.username}'
+  $stream_processor_restapi_password = '${admin.password}'
 
-  $api_store = {
-    url        => 'https://localhost:${mgt.transport.https.port}/store',
-    server_url => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username   => '${admin.username}',
-    password   => '${admin.password}'
-  }
+  $api_store_url = 'https://localhost:${mgt.transport.https.port}/store'
+  $api_store_server_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_store_username = '${admin.username}'
+  $api_store_password = '${admin.password}'
 
-  $api_publisher = {
-    url => 'https://localhost:${mgt.transport.https.port}/publisher'
-  }
+  $api_publisher_url = 'https://localhost:${mgt.transport.https.port}/publisher'
 
   # ----- Master-datasources config params -----
-  $wso2am_db = {
-    url               => 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $wso2am_db_url = 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE'
+  $wso2am_db_username = 'wso2carbon'
+  $wso2am_db_password = 'wso2carbon'
+  $wso2am_db_driver = 'org.h2.Driver'
 
-  $wso2am_stat_db = {
-    url               =>
-    'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $stat_db_url = 'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE'
+  $stat_db_username = 'wso2carbon'
+  $stat_db_password = 'wso2carbon'
+  $stat_db_driver = 'org.h2.Driver'
 
-  $wso2_mb_store_db = {
-    url               => 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $mb_store_db_url = 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $mb_store_db_username = 'wso2carbon'
+  $mb_store_db_password = 'wso2carbon'
+  $mb_store_driver = 'org.h2.Driver'
 
   # ----- Carbon.xml config params -----
-  $ports = {
-    offset => 0
-  }
+  $ports_offset = 0
 
-  $key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $key_store_type = 'JKS'
+  $key_store_password = 'wso2carbon'
+  $key_store_key_alias = 'wso2carbon'
+  $key_store_key_password = 'wso2carbon'
 
-  $internal_key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $internal_key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $internal_key_store_type = 'JKS'
+  $internal_key_store_password = 'wso2carbon'
+  $internal_key_store_key_alias = 'wso2carbon'
+  $internal_key_store_key_password = 'wso2carbon'
 
-  $trust_store = {
-    location => '${carbon.home}/repository/resources/security/client-truststore.jks',
-    type     => 'JKS',
-    password => 'wso2carbon'
-  }
+  $trust_store = '${carbon.home}/repository/resources/security/client-truststore.jks'
+  $trust_store_type = 'JKS'
+  $trust_store_password = 'wso2carbon'
 }

--- a/modules/apim_publisher/templates/carbon-home/repository/conf/api-manager.xml.erb
+++ b/modules/apim_publisher/templates/carbon-home/repository/conf/api-manager.xml.erb
@@ -16,14 +16,14 @@
          logic relies on this. -->
     <AuthManager>
         <!-- Server URL of the Authentication service -->
-        <ServerURL><%= @auth_manager['server_url'] %></ServerURL>
+        <ServerURL><%= @auth_manager_url %></ServerURL>
         <!-- Admin username for the Authentication manager. -->
-        <Username><%= @auth_manager['username'] %></Username>
+        <Username><%= @auth_manager_username %></Username>
         <!-- Admin password for the Authentication manager. -->
-        <Password><%= @auth_manager['password'] %></Password>
+        <Password><%= @auth_manager_password %></Password>
         <!-- Indicates whether the permissions checking of the user (on the Publisher and Store) should be done
            via a remote service. The check will be done on the local server when false. -->
-        <CheckPermissionsRemotely><%= @auth_manager['check_permission_remotely'] %></CheckPermissionsRemotely>
+        <CheckPermissionsRemotely><%= @auth_manager_check_permission_remotely %></CheckPermissionsRemotely>
     </AuthManager>
 
     <JWTConfiguration>
@@ -85,15 +85,15 @@
                 <Name>Production and Sandbox</Name>
                 <Description>This is a hybrid gateway that handles both production and sandbox token traffic.</Description>
                 <!-- Server URL of the API gateway -->
-                <ServerURL><%= @api_gateway['server_url'] %></ServerURL>
+                <ServerURL><%= @api_gateway_url %></ServerURL>
 		        <!-- Admin username for the API gateway. -->
-                <Username><%= @api_gateway['username'] %></Username>
+                <Username><%= @api_gateway_username %></Username>
                 <!-- Admin password for the API gateway.-->
-                <Password><%= @api_gateway['password'] %></Password>
+                <Password><%= @api_gateway_password %></Password>
                 <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
-                <GatewayEndpoint><%= @api_gateway['gateway_endpoint'] %></GatewayEndpoint>
+                <GatewayEndpoint><%= @api_gateway_endpoint %></GatewayEndpoint>
                 <!-- Endpoint of the Websocket APIs hosted in this API Gateway -->
-                <GatewayWSEndpoint><%= @api_gateway['gateway_ws_endpoint'] %></GatewayWSEndpoint>
+                <GatewayWSEndpoint><%= @api_gateway_ws_endpoint %></GatewayWSEndpoint>
             </Environment>
         </Environments>
     </APIGateway>
@@ -139,7 +139,7 @@
     -->
     <Analytics>
         <!-- Enable Analytics for API Manager -->
-        <Enabled><%= @analytics['enabled'] %></Enabled>
+        <Enabled><%= @analytics_enable %></Enabled>
 
         <!-- Server URL of the remote StreamProcessor server used to collect statistics. Must
              be specified in protocol://hostname:port/ format.
@@ -151,20 +151,20 @@
 
              Ex - Multiple Receiver Groups with two receivers each
              {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
-        <StreamProcessorServerURL><%= @analytics['sp_server_url'] %></StreamProcessorServerURL>
+        <StreamProcessorServerURL><%= @stream_processor_url %></StreamProcessorServerURL>
         <!--StreamProcessorAuthServerURL>{ssl://localhost:7712}</StreamProcessorAuthServerURL-->
         <!-- Administrator username to login to the remote StreamProcessor server. -->
-        <StreamProcessorUsername><%= @analytics['sp_username'] %></StreamProcessorUsername>
+        <StreamProcessorUsername><%= @stream_processor_username %></StreamProcessorUsername>
         <!-- Administrator password to login to the remote StreamProcessor server. -->
-        <StreamProcessorPassword><%= @analytics['sp_password'] %></StreamProcessorPassword>
+        <StreamProcessorPassword><%= @stream_processor_password %></StreamProcessorPassword>
 
         <!-- For APIM implemented Statistic client for RDBMS -->
         <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRestClientImpl</StatsProviderImpl>
 
         <!-- StreamProcessor REST API configuration -->
-        <StreamProcessorRestApiURL><%= @analytics['sp_restapi_url'] %></StreamProcessorRestApiURL>
-        <StreamProcessorRestApiUsername><%= @analytics['sp_restapi_username'] %></StreamProcessorRestApiUsername>
-        <StreamProcessorRestApiPassword><%= @analytics['sp_restapi_password'] %></StreamProcessorRestApiPassword>
+        <StreamProcessorRestApiURL><%= @stream_processor_restapi_url %></StreamProcessorRestApiURL>
+        <StreamProcessorRestApiUsername><%= @stream_processor_restapi_username %></StreamProcessorRestApiUsername>
+        <StreamProcessorRestApiPassword><%= @stream_processor_restapi_password %></StreamProcessorRestApiPassword>
 
         <!-- Below property is used to skip trying to connect to event receiver nodes when publishing events even if
             the stats enabled flag is set to true. -->
@@ -301,15 +301,15 @@
         <!--This property is used to indicate how we do user name comparision for token generation https://wso2.org/jira/browse/APIMANAGER-2225-->
         <CompareCaseInsensitively>true</CompareCaseInsensitively>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_store['url'] %></URL>
+        <URL><%= @api_store_url %></URL>
 
         <!-- Server URL of the API Store. -->
-        <ServerURL><%= @api_store['server_url'] %></ServerURL>
+        <ServerURL><%= @api_store_server_url %></ServerURL>
         <!-- Admin username for API Store. -->
-        <Username><%= @api_store['username'] %></Username>
+        <Username><%= @api_store_username %></Username>
 
         <!-- Admin password for API Store. -->
-        <Password><%= @api_store['password'] %></Password>
+        <Password><%= @api_store_password %></Password>
         <!-- This parameter specifies whether to display multiple versions of same
              API or only showing the latest version of an API. -->
         <DisplayMultipleVersions>false</DisplayMultipleVersions>
@@ -340,7 +340,7 @@
 
     <APIPublisher>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_publisher['url'] %></URL>
+        <URL><%= @api_publisher_url %></URL>
         <!-- This parameter specifies enabling the capability of setting API documentation level granular visibility levels.
              By default any document associate with an API will have the same permissions set as the API.With enabling below
              property,it will show two additional permission levels as visible only to all registered users in a particular

--- a/modules/apim_publisher/templates/carbon-home/repository/conf/carbon.xml.erb
+++ b/modules/apim_publisher/templates/carbon-home/repository/conf/carbon.xml.erb
@@ -124,7 +124,7 @@
          the define value + Offset.
          e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
          -->
-        <Offset><%= @ports['offset'] %></Offset>
+        <Offset><%= @ports_offset %></Offset>
 
         <!-- The JMX Ports -->
         <JMX>
@@ -390,15 +390,15 @@
         -->
         <KeyStore>
             <!-- Keystore file location-->
-            <Location><%= @key_store['location'] %></Location>
+            <Location><%= @key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @key_store['type'] %></Type>
+            <Type><%= @key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @key_store['password'] %></Password>
+            <Password><%= @key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @key_store_key_password %></KeyPassword>
         </KeyStore>
 
         <!--
@@ -407,15 +407,15 @@
         -->
         <InternalKeyStore>
             <!-- Keystore file location-->
-            <Location><%= @internal_key_store['location'] %></Location>
+            <Location><%= @internal_key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @internal_key_store['type'] %></Type>
+            <Type><%= @internal_key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @internal_key_store['password'] %></Password>
+            <Password><%= @internal_key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @internal_key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @internal_key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @internal_key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @internal_key_store_key_password %></KeyPassword>
         </InternalKeyStore>
 
         <!--
@@ -424,11 +424,11 @@
         -->
         <TrustStore>
             <!-- trust-store file location -->
-            <Location><%= @trust_store['location'] %></Location>
+            <Location><%= @trust_store %></Location>
             <!-- trust-store type (JKS/PKCS12 etc.) -->
-            <Type><%= @trust_store['type'] %></Type>
+            <Type><%= @trust_store_type %></Type>
             <!-- trust-store password -->
-            <Password><%= @trust_store['password'] %></Password>
+            <Password><%= @trust_store_password %></Password>
         </TrustStore>
 
         <!--

--- a/modules/apim_publisher/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
+++ b/modules/apim_publisher/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
@@ -36,11 +36,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_db['url'] %></url>
-                    <username><%= @wso2am_db['username'] %></username>
-                    <password><%= @wso2am_db['password'] %></password>
+                    <url><%= @wso2am_db_url %></url>
+                    <username><%= @wso2am_db_username %></username>
+                    <password><%= @wso2am_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @wso2am_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -58,11 +58,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_stat_db['url'] %></url>
-                    <username><%= @wso2am_stat_db['username'] %></username>
-                    <password><%= @wso2am_stat_db['password'] %></password>
+                    <url><%= @stat_db_url %></url>
+                    <username><%= @stat_db_username %></username>
+                    <password><%= @stat_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_stat_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @stat_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -80,10 +80,10 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2_mb_store_db['url'] %></url>
-                    <username><%= @wso2_mb_store_db['username'] %></username>
-                    <password><%= @wso2_mb_store_db['password'] %></password>
-                    <driverClassName><%= @wso2_mb_store_db['driver_class_name'] %></driverClassName>
+                    <url><%= @mb_store_db_url %></url>
+                    <username><%= @mb_store_db_username %></username>
+                    <password><%= @mb_store_db_password %></password>
+                    <driverClassName><%= @mb_store_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>

--- a/modules/apim_store/manifests/init.pp
+++ b/modules/apim_store/manifests/init.pp
@@ -19,14 +19,16 @@
 class apim_store inherits apim_store::params {
 
   if $::osfamily == 'redhat' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.rpm'
-    $installer_provider = 'rpm'
-    $install_path = '/usr/lib64/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
+    $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.deb'
-    $installer_provider = 'dpkg'
-    $install_path = '/usr/lib/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
+    $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -45,25 +47,25 @@ class apim_store inherits apim_store::params {
     system => true,
   }
   # Ensure the installation directory is available
-  file { "/opt/${service_name}":
+  file { "/opt/${product}":
     ensure => 'directory',
     owner  => $user,
     group  => $user_group,
   }
 
   # Copy the installer to the directory
-  file { "/opt/${service_name}/${apim_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${apim_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 API Manager
-  package { $service_name:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${service_name}/${apim_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/apim_store/manifests/params.pp
+++ b/modules/apim_store/manifests/params.pp
@@ -22,7 +22,10 @@ class apim_store::params {
   $user_group = 'wso2'
   $user_home = '/home/$user'
   $user_group_id = 802
+  $product = 'wso2am'
+  $product_version = '2.6.0'
   $service_name = 'wso2am'
+
   $hostname = 'localhost'
   $mgt_hostname = 'localhost'
   $jdk_version = 'jdk1.8.0_192'
@@ -41,91 +44,65 @@ class apim_store::params {
     # 'repository/conf/tomcat/catalina-server.xml',
   ]
 
-
   # ----- api-manager.xml config params -----
-  $auth_manager = {
-    server_url                => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username                  => '${admin.username}',
-    password                  => '${admin.password}',
-    check_permission_remotely => 'false'
-  }
+  $auth_manager_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $auth_manager_username = '${admin.username}'
+  $auth_manager_password = '${admin.password}'
+  $auth_manager_check_permission_remotely = 'false'
 
-  $api_gateway = {
-    server_url          => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username            => '${admin.username}',
-    password            => '${admin.password}',
-    gateway_endpoint    => 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}',
-    gateway_ws_endpoint => 'ws://${carbon.local.ip}:9099'
-  }
+  $api_gateway_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_gateway_username = '${admin.username}'
+  $api_gateway_password = '${admin.password}'
+  $api_gateway_endpoint = 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}'
+  $api_gateway_ws_endpoint = 'ws://${carbon.local.ip}:9099'
 
-  $analytics = {
-    enable              => 'false',
-    sp_server_url       => '{tcp://localhost:7612}',
-    sp_username         => '${admin.username}',
-    sp_password         => '${admin.password}',
-    sp_restapi_url      => 'https://localhost:7444',
-    sp_restapi_username => '${admin.username}',
-    sp_restapi_password => '${admin.password}'
-  }
+  $analytics_enable = 'false'
+  $stream_processor_url = '{tcp://localhost:7612}'
+  $stream_processor_username = '${admin.username}'
+  $stream_processor_password = '${admin.password}'
+  $stream_processor_restapi_url = 'https://localhost:7444'
+  $stream_processor_restapi_username = '${admin.username}'
+  $stream_processor_restapi_password = '${admin.password}'
 
-  $api_store = {
-    url        => 'https://localhost:${mgt.transport.https.port}/store',
-    server_url => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username   => '${admin.username}',
-    password   => '${admin.password}'
-  }
+  $api_store_url = 'https://localhost:${mgt.transport.https.port}/store'
+  $api_store_server_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_store_username = '${admin.username}'
+  $api_store_password = '${admin.password}'
 
-  $api_publisher = {
-    url => 'https://localhost:${mgt.transport.https.port}/publisher'
-  }
+  $api_publisher_url = 'https://localhost:${mgt.transport.https.port}/publisher'
 
   # ----- Master-datasources config params -----
-  $wso2am_db = {
-    url               => 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $wso2am_db_url = 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE'
+  $wso2am_db_username = 'wso2carbon'
+  $wso2am_db_password = 'wso2carbon'
+  $wso2am_db_driver = 'org.h2.Driver'
 
-  $wso2am_stat_db = {
-    url               =>
-    'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $stat_db_url = 'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE'
+  $stat_db_username = 'wso2carbon'
+  $stat_db_password = 'wso2carbon'
+  $stat_db_driver = 'org.h2.Driver'
 
-  $wso2_mb_store_db = {
-    url               => 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $mb_store_db_url = 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $mb_store_db_username = 'wso2carbon'
+  $mb_store_db_password = 'wso2carbon'
+  $mb_store_driver = 'org.h2.Driver'
 
   # ----- Carbon.xml config params -----
-  $ports = {
-    offset => 0
-  }
+  $ports_offset = 0
 
-  $key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $key_store_type = 'JKS'
+  $key_store_password = 'wso2carbon'
+  $key_store_key_alias = 'wso2carbon'
+  $key_store_key_password = 'wso2carbon'
 
-  $internal_key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $internal_key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $internal_key_store_type = 'JKS'
+  $internal_key_store_password = 'wso2carbon'
+  $internal_key_store_key_alias = 'wso2carbon'
+  $internal_key_store_key_password = 'wso2carbon'
 
-  $trust_store = {
-    location => '${carbon.home}/repository/resources/security/client-truststore.jks',
-    type     => 'JKS',
-    password => 'wso2carbon'
-  }
+  $trust_store = '${carbon.home}/repository/resources/security/client-truststore.jks'
+  $trust_store_type = 'JKS'
+  $trust_store_password = 'wso2carbon'
 }

--- a/modules/apim_store/templates/carbon-home/repository/conf/api-manager.xml.erb
+++ b/modules/apim_store/templates/carbon-home/repository/conf/api-manager.xml.erb
@@ -16,14 +16,14 @@
          logic relies on this. -->
     <AuthManager>
         <!-- Server URL of the Authentication service -->
-        <ServerURL><%= @auth_manager['server_url'] %></ServerURL>
+        <ServerURL><%= @auth_manager_url %></ServerURL>
         <!-- Admin username for the Authentication manager. -->
-        <Username><%= @auth_manager['username'] %></Username>
+        <Username><%= @auth_manager_username %></Username>
         <!-- Admin password for the Authentication manager. -->
-        <Password><%= @auth_manager['password'] %></Password>
+        <Password><%= @auth_manager_password %></Password>
         <!-- Indicates whether the permissions checking of the user (on the Publisher and Store) should be done
            via a remote service. The check will be done on the local server when false. -->
-        <CheckPermissionsRemotely><%= @auth_manager['check_permission_remotely'] %></CheckPermissionsRemotely>
+        <CheckPermissionsRemotely><%= @auth_manager_check_permission_remotely %></CheckPermissionsRemotely>
     </AuthManager>
 
     <JWTConfiguration>
@@ -85,15 +85,15 @@
                 <Name>Production and Sandbox</Name>
                 <Description>This is a hybrid gateway that handles both production and sandbox token traffic.</Description>
                 <!-- Server URL of the API gateway -->
-                <ServerURL><%= @api_gateway['server_url'] %></ServerURL>
+                <ServerURL><%= @api_gateway_url %></ServerURL>
 		        <!-- Admin username for the API gateway. -->
-                <Username><%= @api_gateway['username'] %></Username>
+                <Username><%= @api_gateway_username %></Username>
                 <!-- Admin password for the API gateway.-->
-                <Password><%= @api_gateway['password'] %></Password>
+                <Password><%= @api_gateway_password %></Password>
                 <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
-                <GatewayEndpoint><%= @api_gateway['gateway_endpoint'] %></GatewayEndpoint>
+                <GatewayEndpoint><%= @api_gateway_endpoint %></GatewayEndpoint>
                 <!-- Endpoint of the Websocket APIs hosted in this API Gateway -->
-                <GatewayWSEndpoint><%= @api_gateway['gateway_ws_endpoint'] %></GatewayWSEndpoint>
+                <GatewayWSEndpoint><%= @api_gateway_ws_endpoint %></GatewayWSEndpoint>
             </Environment>
         </Environments>
     </APIGateway>
@@ -139,7 +139,7 @@
     -->
     <Analytics>
         <!-- Enable Analytics for API Manager -->
-        <Enabled><%= @analytics['enabled'] %></Enabled>
+        <Enabled><%= @analytics_enable %></Enabled>
 
         <!-- Server URL of the remote StreamProcessor server used to collect statistics. Must
              be specified in protocol://hostname:port/ format.
@@ -151,20 +151,20 @@
 
              Ex - Multiple Receiver Groups with two receivers each
              {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
-        <StreamProcessorServerURL><%= @analytics['sp_server_url'] %></StreamProcessorServerURL>
+        <StreamProcessorServerURL><%= @stream_processor_url %></StreamProcessorServerURL>
         <!--StreamProcessorAuthServerURL>{ssl://localhost:7712}</StreamProcessorAuthServerURL-->
         <!-- Administrator username to login to the remote StreamProcessor server. -->
-        <StreamProcessorUsername><%= @analytics['sp_username'] %></StreamProcessorUsername>
+        <StreamProcessorUsername><%= @stream_processor_username %></StreamProcessorUsername>
         <!-- Administrator password to login to the remote StreamProcessor server. -->
-        <StreamProcessorPassword><%= @analytics['sp_password'] %></StreamProcessorPassword>
+        <StreamProcessorPassword><%= @stream_processor_password %></StreamProcessorPassword>
 
         <!-- For APIM implemented Statistic client for RDBMS -->
         <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRestClientImpl</StatsProviderImpl>
 
         <!-- StreamProcessor REST API configuration -->
-        <StreamProcessorRestApiURL><%= @analytics['sp_restapi_url'] %></StreamProcessorRestApiURL>
-        <StreamProcessorRestApiUsername><%= @analytics['sp_restapi_username'] %></StreamProcessorRestApiUsername>
-        <StreamProcessorRestApiPassword><%= @analytics['sp_restapi_password'] %></StreamProcessorRestApiPassword>
+        <StreamProcessorRestApiURL><%= @stream_processor_restapi_url %></StreamProcessorRestApiURL>
+        <StreamProcessorRestApiUsername><%= @stream_processor_restapi_username %></StreamProcessorRestApiUsername>
+        <StreamProcessorRestApiPassword><%= @stream_processor_restapi_password %></StreamProcessorRestApiPassword>
 
         <!-- Below property is used to skip trying to connect to event receiver nodes when publishing events even if
             the stats enabled flag is set to true. -->
@@ -301,15 +301,15 @@
         <!--This property is used to indicate how we do user name comparision for token generation https://wso2.org/jira/browse/APIMANAGER-2225-->
         <CompareCaseInsensitively>true</CompareCaseInsensitively>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_store['url'] %></URL>
+        <URL><%= @api_store_url %></URL>
 
         <!-- Server URL of the API Store. -->
-        <ServerURL><%= @api_store['server_url'] %></ServerURL>
+        <ServerURL><%= @api_store_server_url %></ServerURL>
         <!-- Admin username for API Store. -->
-        <Username><%= @api_store['username'] %></Username>
+        <Username><%= @api_store_username %></Username>
 
         <!-- Admin password for API Store. -->
-        <Password><%= @api_store['password'] %></Password>
+        <Password><%= @api_store_password %></Password>
         <!-- This parameter specifies whether to display multiple versions of same
              API or only showing the latest version of an API. -->
         <DisplayMultipleVersions>false</DisplayMultipleVersions>
@@ -340,7 +340,7 @@
 
     <APIPublisher>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_publisher['url'] %></URL>
+        <URL><%= @api_publisher_url %></URL>
         <!-- This parameter specifies enabling the capability of setting API documentation level granular visibility levels.
              By default any document associate with an API will have the same permissions set as the API.With enabling below
              property,it will show two additional permission levels as visible only to all registered users in a particular

--- a/modules/apim_store/templates/carbon-home/repository/conf/carbon.xml.erb
+++ b/modules/apim_store/templates/carbon-home/repository/conf/carbon.xml.erb
@@ -124,7 +124,7 @@
          the define value + Offset.
          e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
          -->
-        <Offset><%= @ports['offset'] %></Offset>
+        <Offset><%= @ports_offset %></Offset>
 
         <!-- The JMX Ports -->
         <JMX>
@@ -390,15 +390,15 @@
         -->
         <KeyStore>
             <!-- Keystore file location-->
-            <Location><%= @key_store['location'] %></Location>
+            <Location><%= @key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @key_store['type'] %></Type>
+            <Type><%= @key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @key_store['password'] %></Password>
+            <Password><%= @key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @key_store_key_password %></KeyPassword>
         </KeyStore>
 
         <!--
@@ -407,15 +407,15 @@
         -->
         <InternalKeyStore>
             <!-- Keystore file location-->
-            <Location><%= @internal_key_store['location'] %></Location>
+            <Location><%= @internal_key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @internal_key_store['type'] %></Type>
+            <Type><%= @internal_key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @internal_key_store['password'] %></Password>
+            <Password><%= @internal_key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @internal_key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @internal_key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @internal_key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @internal_key_store_key_password %></KeyPassword>
         </InternalKeyStore>
 
         <!--
@@ -424,11 +424,11 @@
         -->
         <TrustStore>
             <!-- trust-store file location -->
-            <Location><%= @trust_store['location'] %></Location>
+            <Location><%= @trust_store %></Location>
             <!-- trust-store type (JKS/PKCS12 etc.) -->
-            <Type><%= @trust_store['type'] %></Type>
+            <Type><%= @trust_store_type %></Type>
             <!-- trust-store password -->
-            <Password><%= @trust_store['password'] %></Password>
+            <Password><%= @trust_store_password %></Password>
         </TrustStore>
 
         <!--

--- a/modules/apim_store/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
+++ b/modules/apim_store/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
@@ -36,11 +36,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_db['url'] %></url>
-                    <username><%= @wso2am_db['username'] %></username>
-                    <password><%= @wso2am_db['password'] %></password>
+                    <url><%= @wso2am_db_url %></url>
+                    <username><%= @wso2am_db_username %></username>
+                    <password><%= @wso2am_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @wso2am_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -58,11 +58,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_stat_db['url'] %></url>
-                    <username><%= @wso2am_stat_db['username'] %></username>
-                    <password><%= @wso2am_stat_db['password'] %></password>
+                    <url><%= @stat_db_url %></url>
+                    <username><%= @stat_db_username %></username>
+                    <password><%= @stat_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_stat_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @stat_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -80,10 +80,10 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2_mb_store_db['url'] %></url>
-                    <username><%= @wso2_mb_store_db['username'] %></username>
-                    <password><%= @wso2_mb_store_db['password'] %></password>
-                    <driverClassName><%= @wso2_mb_store_db['driver_class_name'] %></driverClassName>
+                    <url><%= @mb_store_db_url %></url>
+                    <username><%= @mb_store_db_username %></username>
+                    <password><%= @mb_store_db_password %></password>
+                    <driverClassName><%= @mb_store_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>

--- a/modules/apim_tm/manifests/init.pp
+++ b/modules/apim_tm/manifests/init.pp
@@ -19,14 +19,16 @@
 class apim_tm  inherits apim_tm::params {
 
   if $::osfamily == 'redhat' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.rpm'
-    $installer_provider = 'rpm'
-    $install_path = '/usr/lib64/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.rpm"
+    $installer_provider = 'yum'
+    $install_path = "/usr/lib64/wso2/${product}/${product_version}"
+    $package_name = "${product}-${product_version}"
   }
   elsif $::osfamily == 'debian' {
-    $apim_package = 'wso2am-linux-installer-x64-2.6.0.deb'
-    $installer_provider = 'dpkg'
-    $install_path = '/usr/lib/wso2/wso2am/2.6.0'
+    $product_package = "${product}-linux-installer-x64-${product_version}.deb"
+    $installer_provider = 'apt'
+    $install_path = "/usr/lib/wso2/${product}/${product_version}"
+    $package_name = "/opt/${product}/${product_package}"
   }
 
   # Create wso2 group
@@ -45,25 +47,25 @@ class apim_tm  inherits apim_tm::params {
     system => true,
   }
   # Ensure the installation directory is available
-  file { "/opt/${service_name}":
+  file { "/opt/${product}":
     ensure => 'directory',
     owner  => $user,
     group  => $user_group,
   }
 
   # Copy the installer to the directory
-  file { "/opt/${service_name}/${apim_package}":
+  file { "/opt/${product}/${product_package}":
     owner  => $user,
     group  => $user_group,
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${apim_package}",
+    source => "puppet:///modules/${module_name}/${product_package}",
   }
 
   # Install WSO2 API Manager
-  package { $service_name:
+  package { $package_name:
     ensure   => installed,
     provider => $installer_provider,
-    source   => "/opt/${service_name}/${apim_package}"
+    source  => "/opt/${product}/${product_package}"
   }
 
   # Change the ownership of the installation directory to wso2 user & group

--- a/modules/apim_tm/manifests/params.pp
+++ b/modules/apim_tm/manifests/params.pp
@@ -22,7 +22,10 @@ class apim_tm::params {
   $user_group = 'wso2'
   $user_home = '/home/$user'
   $user_group_id = 802
+  $product = 'wso2am'
+  $product_version = '2.6.0'
   $service_name = 'wso2am'
+
   $hostname = 'localhost'
   $mgt_hostname = 'localhost'
   $jdk_version = 'jdk1.8.0_192'
@@ -41,91 +44,65 @@ class apim_tm::params {
     # 'repository/conf/tomcat/catalina-server.xml',
   ]
 
-
   # ----- api-manager.xml config params -----
-  $auth_manager = {
-    server_url                => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username                  => '${admin.username}',
-    password                  => '${admin.password}',
-    check_permission_remotely => 'false'
-  }
+  $auth_manager_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $auth_manager_username = '${admin.username}'
+  $auth_manager_password = '${admin.password}'
+  $auth_manager_check_permission_remotely = 'false'
 
-  $api_gateway = {
-    server_url          => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username            => '${admin.username}',
-    password            => '${admin.password}',
-    gateway_endpoint    => 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}',
-    gateway_ws_endpoint => 'ws://${carbon.local.ip}:9099'
-  }
+  $api_gateway_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_gateway_username = '${admin.username}'
+  $api_gateway_password = '${admin.password}'
+  $api_gateway_endpoint = 'http://${carbon.local.ip}:${http.nio.port},https://${carbon.local.ip}:${https.nio.port}'
+  $api_gateway_ws_endpoint = 'ws://${carbon.local.ip}:9099'
 
-  $analytics = {
-    enable              => 'false',
-    sp_server_url       => '{tcp://localhost:7612}',
-    sp_username         => '${admin.username}',
-    sp_password         => '${admin.password}',
-    sp_restapi_url      => 'https://localhost:7444',
-    sp_restapi_username => '${admin.username}',
-    sp_restapi_password => '${admin.password}'
-  }
+  $analytics_enable = 'false'
+  $stream_processor_url = '{tcp://localhost:7612}'
+  $stream_processor_username = '${admin.username}'
+  $stream_processor_password = '${admin.password}'
+  $stream_processor_restapi_url = 'https://localhost:7444'
+  $stream_processor_restapi_username = '${admin.username}'
+  $stream_processor_restapi_password = '${admin.password}'
 
-  $api_store = {
-    url        => 'https://localhost:${mgt.transport.https.port}/store',
-    server_url => 'https://localhost:${mgt.transport.https.port}${carbon.context}services/',
-    username   => '${admin.username}',
-    password   => '${admin.password}'
-  }
+  $api_store_url = 'https://localhost:${mgt.transport.https.port}/store'
+  $api_store_server_url = 'https://localhost:${mgt.transport.https.port}${carbon.context}services/'
+  $api_store_username = '${admin.username}'
+  $api_store_password = '${admin.password}'
 
-  $api_publisher = {
-    url => 'https://localhost:${mgt.transport.https.port}/publisher'
-  }
+  $api_publisher_url = 'https://localhost:${mgt.transport.https.port}/publisher'
 
   # ----- Master-datasources config params -----
-  $wso2am_db = {
-    url               => 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $wso2am_db_url = 'jdbc:h2:repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE'
+  $wso2am_db_username = 'wso2carbon'
+  $wso2am_db_password = 'wso2carbon'
+  $wso2am_db_driver = 'org.h2.Driver'
 
-  $wso2am_stat_db = {
-    url               =>
-    'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $stat_db_url = 'jdbc:h2:../tmpStatDB/WSO2AM_STATS_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000;AUTO_SERVER=TRUE'
+  $stat_db_username = 'wso2carbon'
+  $stat_db_password = 'wso2carbon'
+  $stat_db_driver = 'org.h2.Driver'
 
-  $wso2_mb_store_db = {
-    url               => 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000',
-    username          => 'wso2carbon',
-    password          => 'wso2carbon',
-    driver_class_name => 'org.h2.Driver',
-  }
+  $mb_store_db_url = 'jdbc:h2:repository/database/WSO2MB_DB;DB_CLOSE_ON_EXIT=FALSE;LOCK_TIMEOUT=60000'
+  $mb_store_db_username = 'wso2carbon'
+  $mb_store_db_password = 'wso2carbon'
+  $mb_store_driver = 'org.h2.Driver'
 
   # ----- Carbon.xml config params -----
-  $ports = {
-    offset => 0
-  }
+  $ports_offset = 0
 
-  $key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $key_store_type = 'JKS'
+  $key_store_password = 'wso2carbon'
+  $key_store_key_alias = 'wso2carbon'
+  $key_store_key_password = 'wso2carbon'
 
-  $internal_key_store = {
-    location     => '${carbon.home}/repository/resources/security/wso2carbon.jks',
-    type         => 'JKS',
-    password     => 'wso2carbon',
-    key_alias    => 'wso2carbon',
-    key_password => 'wso2carbon',
-  }
+  $internal_key_store = '${carbon.home}/repository/resources/security/wso2carbon.jks'
+  $internal_key_store_type = 'JKS'
+  $internal_key_store_password = 'wso2carbon'
+  $internal_key_store_key_alias = 'wso2carbon'
+  $internal_key_store_key_password = 'wso2carbon'
 
-  $trust_store = {
-    location => '${carbon.home}/repository/resources/security/client-truststore.jks',
-    type     => 'JKS',
-    password => 'wso2carbon'
-  }
+  $trust_store = '${carbon.home}/repository/resources/security/client-truststore.jks'
+  $trust_store_type = 'JKS'
+  $trust_store_password = 'wso2carbon'
 }

--- a/modules/apim_tm/templates/carbon-home/repository/conf/api-manager.xml.erb
+++ b/modules/apim_tm/templates/carbon-home/repository/conf/api-manager.xml.erb
@@ -16,14 +16,14 @@
          logic relies on this. -->
     <AuthManager>
         <!-- Server URL of the Authentication service -->
-        <ServerURL><%= @auth_manager['server_url'] %></ServerURL>
+        <ServerURL><%= @auth_manager_url %></ServerURL>
         <!-- Admin username for the Authentication manager. -->
-        <Username><%= @auth_manager['username'] %></Username>
+        <Username><%= @auth_manager_username %></Username>
         <!-- Admin password for the Authentication manager. -->
-        <Password><%= @auth_manager['password'] %></Password>
+        <Password><%= @auth_manager_password %></Password>
         <!-- Indicates whether the permissions checking of the user (on the Publisher and Store) should be done
            via a remote service. The check will be done on the local server when false. -->
-        <CheckPermissionsRemotely><%= @auth_manager['check_permission_remotely'] %></CheckPermissionsRemotely>
+        <CheckPermissionsRemotely><%= @auth_manager_check_permission_remotely %></CheckPermissionsRemotely>
     </AuthManager>
 
     <JWTConfiguration>
@@ -85,15 +85,15 @@
                 <Name>Production and Sandbox</Name>
                 <Description>This is a hybrid gateway that handles both production and sandbox token traffic.</Description>
                 <!-- Server URL of the API gateway -->
-                <ServerURL><%= @api_gateway['server_url'] %></ServerURL>
+                <ServerURL><%= @api_gateway_url %></ServerURL>
 		        <!-- Admin username for the API gateway. -->
-                <Username><%= @api_gateway['username'] %></Username>
+                <Username><%= @api_gateway_username %></Username>
                 <!-- Admin password for the API gateway.-->
-                <Password><%= @api_gateway['password'] %></Password>
+                <Password><%= @api_gateway_password %></Password>
                 <!-- Endpoint URLs for the APIs hosted in this API gateway.-->
-                <GatewayEndpoint><%= @api_gateway['gateway_endpoint'] %></GatewayEndpoint>
+                <GatewayEndpoint><%= @api_gateway_endpoint %></GatewayEndpoint>
                 <!-- Endpoint of the Websocket APIs hosted in this API Gateway -->
-                <GatewayWSEndpoint><%= @api_gateway['gateway_ws_endpoint'] %></GatewayWSEndpoint>
+                <GatewayWSEndpoint><%= @api_gateway_ws_endpoint %></GatewayWSEndpoint>
             </Environment>
         </Environments>
     </APIGateway>
@@ -139,7 +139,7 @@
     -->
     <Analytics>
         <!-- Enable Analytics for API Manager -->
-        <Enabled><%= @analytics['enabled'] %></Enabled>
+        <Enabled><%= @analytics_enable %></Enabled>
 
         <!-- Server URL of the remote StreamProcessor server used to collect statistics. Must
              be specified in protocol://hostname:port/ format.
@@ -151,20 +151,20 @@
 
              Ex - Multiple Receiver Groups with two receivers each
              {tcp://localhost:7612/,tcp://localhost:7613},{tcp://localhost:7712/,tcp://localhost:7713/} -->
-        <StreamProcessorServerURL><%= @analytics['sp_server_url'] %></StreamProcessorServerURL>
+        <StreamProcessorServerURL><%= @stream_processor_url %></StreamProcessorServerURL>
         <!--StreamProcessorAuthServerURL>{ssl://localhost:7712}</StreamProcessorAuthServerURL-->
         <!-- Administrator username to login to the remote StreamProcessor server. -->
-        <StreamProcessorUsername><%= @analytics['sp_username'] %></StreamProcessorUsername>
+        <StreamProcessorUsername><%= @stream_processor_username %></StreamProcessorUsername>
         <!-- Administrator password to login to the remote StreamProcessor server. -->
-        <StreamProcessorPassword><%= @analytics['sp_password'] %></StreamProcessorPassword>
+        <StreamProcessorPassword><%= @stream_processor_password %></StreamProcessorPassword>
 
         <!-- For APIM implemented Statistic client for RDBMS -->
         <StatsProviderImpl>org.wso2.carbon.apimgt.usage.client.impl.APIUsageStatisticsRestClientImpl</StatsProviderImpl>
 
         <!-- StreamProcessor REST API configuration -->
-        <StreamProcessorRestApiURL><%= @analytics['sp_restapi_url'] %></StreamProcessorRestApiURL>
-        <StreamProcessorRestApiUsername><%= @analytics['sp_restapi_username'] %></StreamProcessorRestApiUsername>
-        <StreamProcessorRestApiPassword><%= @analytics['sp_restapi_password'] %></StreamProcessorRestApiPassword>
+        <StreamProcessorRestApiURL><%= @stream_processor_restapi_url %></StreamProcessorRestApiURL>
+        <StreamProcessorRestApiUsername><%= @stream_processor_restapi_username %></StreamProcessorRestApiUsername>
+        <StreamProcessorRestApiPassword><%= @stream_processor_restapi_password %></StreamProcessorRestApiPassword>
 
         <!-- Below property is used to skip trying to connect to event receiver nodes when publishing events even if
             the stats enabled flag is set to true. -->
@@ -301,15 +301,15 @@
         <!--This property is used to indicate how we do user name comparision for token generation https://wso2.org/jira/browse/APIMANAGER-2225-->
         <CompareCaseInsensitively>true</CompareCaseInsensitively>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_store['url'] %></URL>
+        <URL><%= @api_store_url %></URL>
 
         <!-- Server URL of the API Store. -->
-        <ServerURL><%= @api_store['server_url'] %></ServerURL>
+        <ServerURL><%= @api_store_server_url %></ServerURL>
         <!-- Admin username for API Store. -->
-        <Username><%= @api_store['username'] %></Username>
+        <Username><%= @api_store_username %></Username>
 
         <!-- Admin password for API Store. -->
-        <Password><%= @api_store['password'] %></Password>
+        <Password><%= @api_store_password %></Password>
         <!-- This parameter specifies whether to display multiple versions of same
              API or only showing the latest version of an API. -->
         <DisplayMultipleVersions>false</DisplayMultipleVersions>
@@ -340,7 +340,7 @@
 
     <APIPublisher>
         <DisplayURL>false</DisplayURL>
-        <URL><%= @api_publisher['url'] %></URL>
+        <URL><%= @api_publisher_url %></URL>
         <!-- This parameter specifies enabling the capability of setting API documentation level granular visibility levels.
              By default any document associate with an API will have the same permissions set as the API.With enabling below
              property,it will show two additional permission levels as visible only to all registered users in a particular

--- a/modules/apim_tm/templates/carbon-home/repository/conf/carbon.xml.erb
+++ b/modules/apim_tm/templates/carbon-home/repository/conf/carbon.xml.erb
@@ -124,7 +124,7 @@
          the define value + Offset.
          e.g. Offset=2 and HTTPS port=9443 will set the effective HTTPS port to 9445
          -->
-        <Offset><%= @ports['offset'] %></Offset>
+        <Offset><%= @ports_offset %></Offset>
 
         <!-- The JMX Ports -->
         <JMX>
@@ -390,15 +390,15 @@
         -->
         <KeyStore>
             <!-- Keystore file location-->
-            <Location><%= @key_store['location'] %></Location>
+            <Location><%= @key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @key_store['type'] %></Type>
+            <Type><%= @key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @key_store['password'] %></Password>
+            <Password><%= @key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @key_store_key_password %></KeyPassword>
         </KeyStore>
 
         <!--
@@ -407,15 +407,15 @@
         -->
         <InternalKeyStore>
             <!-- Keystore file location-->
-            <Location><%= @internal_key_store['location'] %></Location>
+            <Location><%= @internal_key_store %></Location>
             <!-- Keystore type (JKS/PKCS12 etc.)-->
-            <Type><%= @internal_key_store['type'] %></Type>
+            <Type><%= @internal_key_store_type %></Type>
             <!-- Keystore password-->
-            <Password><%= @internal_key_store['password'] %></Password>
+            <Password><%= @internal_key_store_password %></Password>
             <!-- Private Key alias-->
-            <KeyAlias><%= @internal_key_store['key_alias'] %></KeyAlias>
+            <KeyAlias><%= @internal_key_store_key_alias %></KeyAlias>
             <!-- Private Key password-->
-            <KeyPassword><%= @internal_key_store['key_password'] %></KeyPassword>
+            <KeyPassword><%= @internal_key_store_key_password %></KeyPassword>
         </InternalKeyStore>
 
         <!--
@@ -424,11 +424,11 @@
         -->
         <TrustStore>
             <!-- trust-store file location -->
-            <Location><%= @trust_store['location'] %></Location>
+            <Location><%= @trust_store %></Location>
             <!-- trust-store type (JKS/PKCS12 etc.) -->
-            <Type><%= @trust_store['type'] %></Type>
+            <Type><%= @trust_store_type %></Type>
             <!-- trust-store password -->
-            <Password><%= @trust_store['password'] %></Password>
+            <Password><%= @trust_store_password %></Password>
         </TrustStore>
 
         <!--

--- a/modules/apim_tm/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
+++ b/modules/apim_tm/templates/carbon-home/repository/conf/datasources/master-datasources.xml.erb
@@ -36,11 +36,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_db['url'] %></url>
-                    <username><%= @wso2am_db['username'] %></username>
-                    <password><%= @wso2am_db['password'] %></password>
+                    <url><%= @wso2am_db_url %></url>
+                    <username><%= @wso2am_db_username %></username>
+                    <password><%= @wso2am_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @wso2am_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -58,11 +58,11 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2am_stat_db['url'] %></url>
-                    <username><%= @wso2am_stat_db['username'] %></username>
-                    <password><%= @wso2am_stat_db['password'] %></password>
+                    <url><%= @stat_db_url %></url>
+                    <username><%= @stat_db_username %></username>
+                    <password><%= @stat_db_password %></password>
                     <defaultAutoCommit>true</defaultAutoCommit>
-                    <driverClassName><%= @wso2am_stat_db['driver_class_name'] %></driverClassName>
+                    <driverClassName><%= @stat_db_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>
@@ -80,10 +80,10 @@
             </jndiConfig>
             <definition type="RDBMS">
                 <configuration>
-                    <url><%= @wso2_mb_store_db['url'] %></url>
-                    <username><%= @wso2_mb_store_db['username'] %></username>
-                    <password><%= @wso2_mb_store_db['password'] %></password>
-                    <driverClassName><%= @wso2_mb_store_db['driver_class_name'] %></driverClassName>
+                    <url><%= @mb_store_db_url %></url>
+                    <username><%= @mb_store_db_username %></username>
+                    <password><%= @mb_store_db_password %></password>
+                    <driverClassName><%= @mb_store_driver %></driverClassName>
                     <maxActive>50</maxActive>
                     <maxWait>60000</maxWait>
                     <testOnBorrow>true</testOnBorrow>


### PR DESCRIPTION
## Purpose
> Resolve https://github.com/wso2/puppet-apim/issues/73 and params readabiltiy.

## Goals
> Ensure Puppet 5 APIM 2.6.0 runs without an issue.

## Approach
> Remove 2 layer params config and make it a single level config.
> For https://github.com/wso2/puppet-apim/issues/73, change package installers to `apt` and `yum`

## Test environment
> Ubuntu 18.04 ( Bionic Beaver) with puppet 5.4.0
> CentOS 7 with puppet 5.5.6
 