### PR TITLE
Move product distributions outside modules

### DIFF
--- a/modules/apim/manifests/init.pp
+++ b/modules/apim/manifests/init.pp
@@ -46,7 +46,7 @@ class apim inherits apim::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/apim_analytics_dashboard/manifests/init.pp
+++ b/modules/apim_analytics_dashboard/manifests/init.pp
@@ -46,7 +46,7 @@ class apim_analytics_dashboard inherits apim_analytics_dashboard::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/apim_analytics_dashboard_master/manifests/init.pp
+++ b/modules/apim_analytics_dashboard_master/manifests/init.pp
@@ -30,7 +30,7 @@ class apim_analytics_dashboard_master inherits apim_analytics_dashboard_master::
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/apim_analytics_worker/manifests/init.pp
+++ b/modules/apim_analytics_worker/manifests/init.pp
@@ -46,7 +46,7 @@ class apim_analytics_worker inherits apim_analytics_worker::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/apim_analytics_worker_master/manifests/init.pp
+++ b/modules/apim_analytics_worker_master/manifests/init.pp
@@ -30,7 +30,7 @@ class apim_analytics_worker_master inherits apim_analytics_worker_master::params
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/apim_gateway/manifests/init.pp
+++ b/modules/apim_gateway/manifests/init.pp
@@ -46,7 +46,7 @@ class apim_gateway inherits apim_gateway::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/apim_gateway_master/manifests/init.pp
+++ b/modules/apim_gateway_master/manifests/init.pp
@@ -29,7 +29,7 @@ class apim_gateway_master inherits apim_gateway_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/apim_km/manifests/init.pp
+++ b/modules/apim_km/manifests/init.pp
@@ -46,7 +46,7 @@ class apim_km inherits apim_km::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/apim_km_master/manifests/init.pp
+++ b/modules/apim_km_master/manifests/init.pp
@@ -29,7 +29,7 @@ class apim_km_master inherits apim_km_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/apim_master/build.sh
+++ b/modules/apim_master/build.sh
@@ -142,7 +142,7 @@ then
 
   while read -r line; do
     filepath=${line##*${product}-${product_version}/}
-    template_file=${puppet_env}/modules/is_master/templates/carbon-home/${filepath}.erb
+    template_file=${puppet_env}/modules/apim_master/templates/carbon-home/${filepath}.erb
     if [[ -f ${template_file} ]]
     then
       updated_templates+=(${template_file})

--- a/modules/apim_master/manifests/init.pp
+++ b/modules/apim_master/manifests/init.pp
@@ -29,7 +29,7 @@ class apim_master inherits apim_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/apim_master/manifests/startserver.pp
+++ b/modules/apim_master/manifests/startserver.pp
@@ -21,5 +21,5 @@ class apim_master::startserver (
 )
   inherits apim_master::params {
 
-  # This class should be used to control Identity Server if required.
+  # This class should be used to control API Manager if required.
 }

--- a/modules/apim_publisher/manifests/init.pp
+++ b/modules/apim_publisher/manifests/init.pp
@@ -46,7 +46,7 @@ class apim_publisher inherits apim_publisher::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/apim_publisher_master/manifests/init.pp
+++ b/modules/apim_publisher_master/manifests/init.pp
@@ -29,7 +29,7 @@ class apim_publisher_master inherits apim_publisher_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/apim_store/manifests/init.pp
+++ b/modules/apim_store/manifests/init.pp
@@ -46,7 +46,7 @@ class apim_store inherits apim_store::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/apim_store_master/manifests/init.pp
+++ b/modules/apim_store_master/manifests/init.pp
@@ -29,7 +29,7 @@ class apim_store_master inherits apim_store_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package

--- a/modules/apim_tm/manifests/init.pp
+++ b/modules/apim_tm/manifests/init.pp
@@ -46,7 +46,7 @@ class apim_tm  inherits apim_tm::params {
   # Copy JDK to Java distribution path
   file { "jdk-distribution":
     path   => "${java_home}.tar.gz",
-    source => "puppet:///modules/${module_name}/${jdk_name}.tar.gz",
+    source => "puppet:///modules/distributions/${jdk_name}.tar.gz",
   }
 
   # Unzip distribution

--- a/modules/apim_tm_master/manifests/init.pp
+++ b/modules/apim_tm_master/manifests/init.pp
@@ -29,7 +29,7 @@ class apim_tm_master inherits apim_tm_master::params {
   file { "binary":
     path   => "${distribution_path}/${product_binary}",
     mode   => '0644',
-    source => "puppet:///modules/${module_name}/${product_binary}",
+    source => "puppet:///modules/distributions/${product_binary}",
   }
 
   # Install the "unzip" package


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/puppet-apim/issues/89

## Goals
> The location of distributions have been moved outside from the `<puppet_env>/modules/<profile>/files` directory to `<puppet_env>/modules/distributions/files`
## Test environment
> Puppet 5.4.0
> Ubuntu 18.04