### PR TITLE
 Save each individual profile in different paths 

### DIFF
--- a/modules/apim_analytics_dashboard/manifests/init.pp
+++ b/modules/apim_analytics_dashboard/manifests/init.pp
@@ -88,9 +88,9 @@ class apim_analytics_dashboard inherits apim_analytics_dashboard::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
+    command     => "kill -term $(cat ${install_path}/wso2/${profile}/runtime.pid)",
     path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
+    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/runtime.pid",
     subscribe   => File["binary"],
     refreshonly => true,
   }

--- a/modules/apim_analytics_worker/manifests/init.pp
+++ b/modules/apim_analytics_worker/manifests/init.pp
@@ -88,9 +88,9 @@ class apim_analytics_worker inherits apim_analytics_worker::params {
 
   # Stop the existing setup
   exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
+    command     => "kill -term $(cat ${install_path}/wso2/${profile}/runtime.pid)",
     path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
+    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/runtime.pid",
     subscribe   => File["binary"],
     refreshonly => true,
   }

--- a/modules/apim_gateway/manifests/init.pp
+++ b/modules/apim_gateway/manifests/init.pp
@@ -63,7 +63,8 @@ class apim_gateway inherits apim_gateway::params {
 
   # Create distribution path
   file { [  "${products_dir}",
-    "${products_dir}/${product}" ]:
+    "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}" ]:
     ensure => 'directory',
   }
 

--- a/modules/apim_gateway/manifests/params.pp
+++ b/modules/apim_gateway/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_gateway::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'gateway'
 
   # JDK Distributions
   if $::osfamily == 'redhat' {
@@ -40,6 +41,6 @@ class apim_gateway::params {
 
   # Product and installation information
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_gateway_master/build.sh
+++ b/modules/apim_gateway_master/build.sh
@@ -23,7 +23,8 @@
 : ${product:="wso2am"}
 : ${product_version:="2.6.0"}
 : ${products_dir:="/usr/local/wso2"}
-: ${distribution_path:=${products_dir}"/"${product}"/"${product_version}}
+: ${profile:="gateway"}
+: ${distribution_path:=${products_dir}"/"${product}"/"${profile}"/"${product_version}}
 : ${install_path:=${distribution_path}"/"${product}"-"${product_version}}
 : ${product_binary:=${product}"-"${product_version}".zip"}
 : ${puppet_env:="/etc/puppet/code/environments/production"}

--- a/modules/apim_gateway_master/manifests/init.pp
+++ b/modules/apim_gateway_master/manifests/init.pp
@@ -21,6 +21,7 @@ class apim_gateway_master inherits apim_gateway_master::params {
   # Create distribution path
   file { [  "${products_dir}",
     "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}",
     "${distribution_path}"]:
     ensure => 'directory',
   }

--- a/modules/apim_gateway_master/manifests/params.pp
+++ b/modules/apim_gateway_master/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_gateway_master::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'gateway'
 
   # Define the templates
   $start_script_template = 'bin/wso2server.sh'
@@ -99,6 +100,6 @@ class apim_gateway_master::params {
 
   # Product and installation paths
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_km/manifests/init.pp
+++ b/modules/apim_km/manifests/init.pp
@@ -63,7 +63,8 @@ class apim_km inherits apim_km::params {
 
   # Create distribution path
   file { [  "${products_dir}",
-    "${products_dir}/${product}" ]:
+    "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}" ]:
     ensure => 'directory',
   }
 

--- a/modules/apim_km/manifests/params.pp
+++ b/modules/apim_km/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_km::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'keymanager'
 
   # JDK Distributions
   if $::osfamily == 'redhat' {
@@ -40,6 +41,6 @@ class apim_km::params {
 
   # Product and installation information
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_km_master/build.sh
+++ b/modules/apim_km_master/build.sh
@@ -23,7 +23,8 @@
 : ${product:="wso2am"}
 : ${product_version:="2.6.0"}
 : ${products_dir:="/usr/local/wso2"}
-: ${distribution_path:=${products_dir}"/"${product}"/"${product_version}}
+: ${profile:="keymanager"}
+: ${distribution_path:=${products_dir}"/"${product}"/"${profile}"/"${product_version}}
 : ${install_path:=${distribution_path}"/"${product}"-"${product_version}}
 : ${product_binary:=${product}"-"${product_version}".zip"}
 : ${puppet_env:="/etc/puppet/code/environments/production"}

--- a/modules/apim_km_master/manifests/init.pp
+++ b/modules/apim_km_master/manifests/init.pp
@@ -21,6 +21,7 @@ class apim_km_master inherits apim_km_master::params {
   # Create distribution path
   file { [  "${products_dir}",
     "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}",
     "${distribution_path}"]:
     ensure => 'directory',
   }

--- a/modules/apim_km_master/manifests/params.pp
+++ b/modules/apim_km_master/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_km_master::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'keymanager'
 
   # Define the templates
   $start_script_template = 'bin/wso2server.sh'
@@ -99,6 +100,6 @@ class apim_km_master::params {
 
   # Product and installation paths
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_publisher/manifests/init.pp
+++ b/modules/apim_publisher/manifests/init.pp
@@ -63,7 +63,8 @@ class apim_publisher inherits apim_publisher::params {
 
   # Create distribution path
   file { [  "${products_dir}",
-    "${products_dir}/${product}" ]:
+    "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}" ]:
     ensure => 'directory',
   }
 

--- a/modules/apim_publisher/manifests/params.pp
+++ b/modules/apim_publisher/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_publisher::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'publisher'
 
   # JDK Distributions
   if $::osfamily == 'redhat' {
@@ -40,6 +41,6 @@ class apim_publisher::params {
 
   # Product and installation information
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_publisher_master/build.sh
+++ b/modules/apim_publisher_master/build.sh
@@ -23,7 +23,8 @@
 : ${product:="wso2am"}
 : ${product_version:="2.6.0"}
 : ${products_dir:="/usr/local/wso2"}
-: ${distribution_path:=${products_dir}"/"${product}"/"${product_version}}
+: ${profile:="publisher"}
+: ${distribution_path:=${products_dir}"/"${product}"/"${profile}"/"${product_version}}
 : ${install_path:=${distribution_path}"/"${product}"-"${product_version}}
 : ${product_binary:=${product}"-"${product_version}".zip"}
 : ${puppet_env:="/etc/puppet/code/environments/production"}

--- a/modules/apim_publisher_master/manifests/init.pp
+++ b/modules/apim_publisher_master/manifests/init.pp
@@ -21,6 +21,7 @@ class apim_publisher_master inherits apim_publisher_master::params {
   # Create distribution path
   file { [  "${products_dir}",
     "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}",
     "${distribution_path}"]:
     ensure => 'directory',
   }

--- a/modules/apim_publisher_master/manifests/params.pp
+++ b/modules/apim_publisher_master/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_publisher_master::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'publisher'
 
   # Define the templates
   $start_script_template = 'bin/wso2server.sh'
@@ -99,6 +100,6 @@ class apim_publisher_master::params {
 
   # Product and installation paths
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_store/manifests/init.pp
+++ b/modules/apim_store/manifests/init.pp
@@ -63,7 +63,8 @@ class apim_store inherits apim_store::params {
 
   # Create distribution path
   file { [  "${products_dir}",
-    "${products_dir}/${product}" ]:
+    "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}" ]:
     ensure => 'directory',
   }
 

--- a/modules/apim_store/manifests/params.pp
+++ b/modules/apim_store/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_store::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'store'
 
   # JDK Distributions
   if $::osfamily == 'redhat' {
@@ -40,6 +41,6 @@ class apim_store::params {
 
   # Product and installation information
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_store_master/build.sh
+++ b/modules/apim_store_master/build.sh
@@ -23,7 +23,8 @@
 : ${product:="wso2am"}
 : ${product_version:="2.6.0"}
 : ${products_dir:="/usr/local/wso2"}
-: ${distribution_path:=${products_dir}"/"${product}"/"${product_version}}
+: ${profile:="store"}
+: ${distribution_path:=${products_dir}"/"${product}"/"${profile}"/"${product_version}}
 : ${install_path:=${distribution_path}"/"${product}"-"${product_version}}
 : ${product_binary:=${product}"-"${product_version}".zip"}
 : ${puppet_env:="/etc/puppet/code/environments/production"}

--- a/modules/apim_store_master/manifests/init.pp
+++ b/modules/apim_store_master/manifests/init.pp
@@ -21,6 +21,7 @@ class apim_store_master inherits apim_store_master::params {
   # Create distribution path
   file { [  "${products_dir}",
     "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}",
     "${distribution_path}"]:
     ensure => 'directory',
   }

--- a/modules/apim_store_master/manifests/params.pp
+++ b/modules/apim_store_master/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_store_master::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'store'
 
   # Define the templates
   $start_script_template = 'bin/wso2server.sh'
@@ -99,6 +100,6 @@ class apim_store_master::params {
 
   # Product and installation paths
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_tm/manifests/init.pp
+++ b/modules/apim_tm/manifests/init.pp
@@ -63,7 +63,8 @@ class apim_tm  inherits apim_tm::params {
 
   # Create distribution path
   file { [  "${products_dir}",
-    "${products_dir}/${product}" ]:
+    "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}" ]:
     ensure => 'directory',
   }
 

--- a/modules/apim_tm/manifests/params.pp
+++ b/modules/apim_tm/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_tm::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'trafficmanager'
 
   # JDK Distributions
   if $::osfamily == 'redhat' {
@@ -40,6 +41,6 @@ class apim_tm::params {
 
   # Product and installation information
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }

--- a/modules/apim_tm_master/build.sh
+++ b/modules/apim_tm_master/build.sh
@@ -23,7 +23,8 @@
 : ${product:="wso2am"}
 : ${product_version:="2.6.0"}
 : ${products_dir:="/usr/local/wso2"}
-: ${distribution_path:=${products_dir}"/"${product}"/"${product_version}}
+: ${profile:="trafficmanager"}
+: ${distribution_path:=${products_dir}"/"${product}"/"${profile}"/"${product_version}}
 : ${install_path:=${distribution_path}"/"${product}"-"${product_version}}
 : ${product_binary:=${product}"-"${product_version}".zip"}
 : ${puppet_env:="/etc/puppet/code/environments/production"}

--- a/modules/apim_tm_master/manifests/init.pp
+++ b/modules/apim_tm_master/manifests/init.pp
@@ -21,6 +21,7 @@ class apim_tm_master inherits apim_tm_master::params {
   # Create distribution path
   file { [  "${products_dir}",
     "${products_dir}/${product}",
+    "${products_dir}/${product}/${profile}",
     "${distribution_path}"]:
     ensure => 'directory',
   }

--- a/modules/apim_tm_master/manifests/params.pp
+++ b/modules/apim_tm_master/manifests/params.pp
@@ -22,6 +22,7 @@ class apim_tm_master::params {
   $product = 'wso2am'
   $product_version = '2.6.0'
   $service_name = 'wso2am'
+  $profile = 'trafficmanager'
 
   # Define the templates
   $start_script_template = 'bin/wso2server.sh'
@@ -99,6 +100,6 @@ class apim_tm_master::params {
 
   # Product and installation paths
   $product_binary = "${product}-${product_version}.zip"
-  $distribution_path = "${products_dir}/${product}/${product_version}"
+  $distribution_path = "${products_dir}/${product}/${profile}/${product_version}"
   $install_path = "${distribution_path}/${product}-${product_version}"
 }


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/puppet-apim/issues/91, Resolves https://github.com/wso2/puppet-apim/issues/92

## Goals
> Kills analytics servers by obtaining the PID from the runtime file
> Fixes issue where each profile gets written to the same path in puppetmaster

## Test environment
> Puppet 5.4.0
> Ubuntu 18.04