### PR TITLE
Fixing Carbon server stop instead of killing the pid and dependency fix in the startserver.pp

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -15,13 +15,17 @@
 #----------------------------------------------------------------------------
 
 # Run stages
+stage { 'begin' }
 stage { 'custom': }
 stage { 'final': }
 
 # Order stages
-Stage['main'] -> Stage['custom'] -> Stage['final']
+Stage['begin'] -> Stage['main'] -> Stage['custom'] -> Stage['final']
 
 node default {
+  class { "::${::profile}::stopserver":
+    stage => 'begin'
+  }
   class { "::${::profile}": }
   class { "::${::profile}::custom":
     stage => 'custom'

--- a/modules/apim/manifests/init.pp
+++ b/modules/apim/manifests/init.pp
@@ -85,24 +85,6 @@ class apim inherits apim::params {
     source => "puppet:///modules/${module_name}/${product_binary}",
   }
 
-  # Stop the existing setup
-  exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
-  # Wait for the server to stop
-  exec { "wait":
-    command     => "sleep 10",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -d ${install_path}",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
   # Delete existing setup
   exec { "detele-pack":
     command     => "rm -rf ${install_path}",

--- a/modules/apim/manifests/params.pp
+++ b/modules/apim/manifests/params.pp
@@ -37,6 +37,10 @@ class apim::params {
 
   $start_script_template = 'bin/wso2server.sh'
 
+  # service stop retry and sleep times in seconds
+  $max_tries = 5
+  $sleep_between_try = 5
+
   # Directories
   $products_dir = "/usr/local/wso2"
 

--- a/modules/apim/manifests/startserver.pp
+++ b/modules/apim/manifests/startserver.pp
@@ -30,5 +30,6 @@ class apim::startserver (
     enable => true,
     ensure => running,
     subscribe => File["binary"],
+    require   => Exec['daemon-reload'],
   }
 }

--- a/modules/apim/manifests/stopserver.pp
+++ b/modules/apim/manifests/stopserver.pp
@@ -14,20 +14,16 @@
 #  limitations under the License.
 # ----------------------------------------------------------------------------
 
-# Class apim_analytics_dashboard::startserver
+# Class apim::stopserver
 # Starts the server as a service in the final stage.
-class apim_analytics_dashboard::startserver inherits apim_analytics_dashboard::params {
+class apim::stopserver (
+  $service_name = $apim::params::service_name
+)
+  inherits apim::params {
 
-  exec { 'daemon-reload':
-    command => "systemctl daemon-reload",
-    path    => "/bin/",
-  }
-
-  # Start the service
-  service { $service_name:
-    enable => true,
-    ensure => running,
-    subscribe => File["binary"],
-    require   => Exec['daemon-reload'],
+  exec { "systemctl stop ${service_name} ":
+    tries     => $max_try,
+    try_sleep => $sleep_between_try,
+    path      => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
   }
 }

--- a/modules/apim_analytics_dashboard/manifests/init.pp
+++ b/modules/apim_analytics_dashboard/manifests/init.pp
@@ -86,23 +86,6 @@ class apim_analytics_dashboard inherits apim_analytics_dashboard::params {
     source => "puppet:///modules/${module_name}/${product_binary}",
   }
 
-  # Stop the existing setup
-  exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2/${profile}/runtime.pid)",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/runtime.pid",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
-  # Wait for the server to stop
-  exec { "wait":
-    command     => "sleep 15",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -d ${install_path}",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
 
   # Delete existing setup
   exec { "detele-pack":

--- a/modules/apim_analytics_dashboard/manifests/params.pp
+++ b/modules/apim_analytics_dashboard/manifests/params.pp
@@ -37,6 +37,10 @@ class apim_analytics_dashboard::params {
   # Define the template
   $start_script_template = "bin/${profile}.sh"
 
+  # service stop retry and sleep times in seconds
+  $max_tries = 5
+  $sleep_between_try = 5
+
   # Directories
   $products_dir = "/usr/local/wso2"
 

--- a/modules/apim_analytics_dashboard/manifests/stopserver.pp
+++ b/modules/apim_analytics_dashboard/manifests/stopserver.pp
@@ -14,20 +14,16 @@
 #  limitations under the License.
 # ----------------------------------------------------------------------------
 
-# Class apim_analytics_dashboard::startserver
+# Class apim_analytics_dashboard::stopserver
 # Starts the server as a service in the final stage.
-class apim_analytics_dashboard::startserver inherits apim_analytics_dashboard::params {
+class apim_analytics_dashboard::stopserver (
+  $service_name = $apim_analytics_dashboard::params::service_name
+)
+  inherits apim_analytics_dashboard::params {
 
-  exec { 'daemon-reload':
-    command => "systemctl daemon-reload",
-    path    => "/bin/",
-  }
-
-  # Start the service
-  service { $service_name:
-    enable => true,
-    ensure => running,
-    subscribe => File["binary"],
-    require   => Exec['daemon-reload'],
+  exec { "systemctl stop ${service_name} ":
+    tries     => $max_try,
+    try_sleep => $sleep_between_try,
+    path      => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
   }
 }

--- a/modules/apim_analytics_worker/manifests/init.pp
+++ b/modules/apim_analytics_worker/manifests/init.pp
@@ -86,23 +86,6 @@ class apim_analytics_worker inherits apim_analytics_worker::params {
     source => "puppet:///modules/${module_name}/${product_binary}",
   }
 
-  # Stop the existing setup
-  exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2/${profile}/runtime.pid)",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2/${profile}/runtime.pid",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
-  # Wait for the server to stop
-  exec { "wait":
-    command     => "sleep 15",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -d ${install_path}",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
 
   # Delete existing setup
   exec { "detele-pack":

--- a/modules/apim_analytics_worker/manifests/params.pp
+++ b/modules/apim_analytics_worker/manifests/params.pp
@@ -37,6 +37,10 @@ class apim_analytics_worker::params {
   # Define the template
   $start_script_template = "bin/${profile}.sh"
 
+  # service stop retry and sleep times in seconds
+  $max_tries = 5
+  $sleep_between_try = 5
+
   # Directories
   $products_dir = "/usr/local/wso2"
 

--- a/modules/apim_analytics_worker/manifests/startserver.pp
+++ b/modules/apim_analytics_worker/manifests/startserver.pp
@@ -28,5 +28,6 @@ class apim_analytics_worker::startserver inherits apim_analytics_worker::params 
     enable => true,
     ensure => running,
     subscribe => File["binary"],
+    require   => Exec['daemon-reload'],
   }
 }

--- a/modules/apim_analytics_worker/manifests/stopserver.pp
+++ b/modules/apim_analytics_worker/manifests/stopserver.pp
@@ -14,20 +14,16 @@
 #  limitations under the License.
 # ----------------------------------------------------------------------------
 
-# Class apim_analytics_dashboard::startserver
+# Class apim_analytics_worker::stopserver
 # Starts the server as a service in the final stage.
-class apim_analytics_dashboard::startserver inherits apim_analytics_dashboard::params {
+class apim_analytics_worker::stopserver (
+  $service_name = $apim_analytics_worker::params::service_name
+)
+  inherits apim_analytics_worker::params {
 
-  exec { 'daemon-reload':
-    command => "systemctl daemon-reload",
-    path    => "/bin/",
-  }
-
-  # Start the service
-  service { $service_name:
-    enable => true,
-    ensure => running,
-    subscribe => File["binary"],
-    require   => Exec['daemon-reload'],
+  exec { "systemctl stop ${service_name} ":
+    tries     => $max_try,
+    try_sleep => $sleep_between_try,
+    path      => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
   }
 }

--- a/modules/apim_gateway/manifests/init.pp
+++ b/modules/apim_gateway/manifests/init.pp
@@ -86,24 +86,6 @@ class apim_gateway inherits apim_gateway::params {
     source => "puppet:///modules/${module_name}/${product_binary}",
   }
 
-  # Stop the existing setup
-  exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
-  # Wait for the server to stop
-  exec { "wait":
-    command     => "sleep 10",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -d ${install_path}",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
   # Delete existing setup
   exec { "detele-pack":
     command     => "rm -rf ${install_path}",

--- a/modules/apim_gateway/manifests/params.pp
+++ b/modules/apim_gateway/manifests/params.pp
@@ -37,6 +37,10 @@ class apim_gateway::params {
 
   $start_script_template = 'bin/wso2server.sh'
 
+  # service stop retry and sleep times in seconds
+  $max_tries = 5
+  $sleep_between_try = 5
+
   # Directories
   $products_dir = "/usr/local/wso2"
 

--- a/modules/apim_gateway/manifests/startserver.pp
+++ b/modules/apim_gateway/manifests/startserver.pp
@@ -27,5 +27,6 @@ class apim_gateway::startserver inherits apim_gateway::params {
     enable    => true,
     ensure    => running,
     subscribe => File["binary"],
+    require   => Exec['daemon-reload'],
   }
 }

--- a/modules/apim_gateway/manifests/stopserver.pp
+++ b/modules/apim_gateway/manifests/stopserver.pp
@@ -14,20 +14,16 @@
 #  limitations under the License.
 # ----------------------------------------------------------------------------
 
-# Class apim_analytics_dashboard::startserver
+# Class apim_gateway::stopserver
 # Starts the server as a service in the final stage.
-class apim_analytics_dashboard::startserver inherits apim_analytics_dashboard::params {
+class apim_gateway::stopserver (
+  $service_name = $apim_gateway::params::service_name
+)
+  inherits apim_gateway::params {
 
-  exec { 'daemon-reload':
-    command => "systemctl daemon-reload",
-    path    => "/bin/",
-  }
-
-  # Start the service
-  service { $service_name:
-    enable => true,
-    ensure => running,
-    subscribe => File["binary"],
-    require   => Exec['daemon-reload'],
+  exec { "systemctl stop ${service_name} ":
+    tries     => $max_try,
+    try_sleep => $sleep_between_try,
+    path      => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
   }
 }

--- a/modules/apim_km/manifests/init.pp
+++ b/modules/apim_km/manifests/init.pp
@@ -86,23 +86,6 @@ class apim_km inherits apim_km::params {
     source => "puppet:///modules/${module_name}/${product_binary}",
   }
 
-  # Stop the existing setup
-  exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
-  # Wait for the server to stop
-  exec { "wait":
-    command     => "sleep 10",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -d ${install_path}",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
 
   # Delete existing setup
   exec { "detele-pack":

--- a/modules/apim_km/manifests/params.pp
+++ b/modules/apim_km/manifests/params.pp
@@ -37,6 +37,10 @@ class apim_km::params {
 
   $start_script_template = 'bin/wso2server.sh'
 
+  # service stop retry and sleep times in seconds
+  $max_tries = 5
+  $sleep_between_try = 5
+
   # Directories
   $products_dir = "/usr/local/wso2"
 

--- a/modules/apim_km/manifests/startserver.pp
+++ b/modules/apim_km/manifests/startserver.pp
@@ -27,5 +27,6 @@ class apim_km::startserver inherits apim_km::params {
     enable    => true,
     ensure    => running,
     subscribe => File["binary"],
+    require   => Exec['daemon-reload'],
   }
 }

--- a/modules/apim_km/manifests/stopserver.pp
+++ b/modules/apim_km/manifests/stopserver.pp
@@ -14,20 +14,16 @@
 #  limitations under the License.
 # ----------------------------------------------------------------------------
 
-# Class apim_analytics_dashboard::startserver
+# Class apim_km::stopserver
 # Starts the server as a service in the final stage.
-class apim_analytics_dashboard::startserver inherits apim_analytics_dashboard::params {
+class apim_km::stopserver (
+  $service_name = $apim_km::params::service_name
+)
+  inherits apim_km::params {
 
-  exec { 'daemon-reload':
-    command => "systemctl daemon-reload",
-    path    => "/bin/",
-  }
-
-  # Start the service
-  service { $service_name:
-    enable => true,
-    ensure => running,
-    subscribe => File["binary"],
-    require   => Exec['daemon-reload'],
+  exec { "systemctl stop ${service_name} ":
+    tries     => $max_try,
+    try_sleep => $sleep_between_try,
+    path      => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
   }
 }

--- a/modules/apim_publisher/manifests/init.pp
+++ b/modules/apim_publisher/manifests/init.pp
@@ -86,24 +86,6 @@ class apim_publisher inherits apim_publisher::params {
     source => "puppet:///modules/${module_name}/${product_binary}",
   }
 
-  # Stop the existing setup
-  exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
-  # Wait for the server to stop
-  exec { "wait":
-    command     => "sleep 10",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -d ${install_path}",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
   # Delete existing setup
   exec { "detele-pack":
     command     => "rm -rf ${install_path}",

--- a/modules/apim_publisher/manifests/params.pp
+++ b/modules/apim_publisher/manifests/params.pp
@@ -37,6 +37,10 @@ class apim_publisher::params {
 
   $start_script_template = 'bin/wso2server.sh'
 
+  # service stop retry and sleep times in seconds
+  $max_tries = 5
+  $sleep_between_try = 5
+
   # Directories
   $products_dir = "/usr/local/wso2"
 

--- a/modules/apim_publisher/manifests/startserver.pp
+++ b/modules/apim_publisher/manifests/startserver.pp
@@ -30,5 +30,6 @@ class apim_publisher::startserver (
     enable    => true,
     ensure    => running,
     subscribe => File["binary"],
+    require   => Exec['daemon-reload'],
   }
 }

--- a/modules/apim_publisher/manifests/stopserver.pp
+++ b/modules/apim_publisher/manifests/stopserver.pp
@@ -14,20 +14,16 @@
 #  limitations under the License.
 # ----------------------------------------------------------------------------
 
-# Class apim_analytics_dashboard::startserver
+# Class apim_publisher::stopserver
 # Starts the server as a service in the final stage.
-class apim_analytics_dashboard::startserver inherits apim_analytics_dashboard::params {
+class apim_publisher::stopserver (
+  $service_name = $apim_publisher::params::service_name
+)
+  inherits apim_publisher::params {
 
-  exec { 'daemon-reload':
-    command => "systemctl daemon-reload",
-    path    => "/bin/",
-  }
-
-  # Start the service
-  service { $service_name:
-    enable => true,
-    ensure => running,
-    subscribe => File["binary"],
-    require   => Exec['daemon-reload'],
+  exec { "systemctl stop ${service_name} ":
+    tries     => $max_try,
+    try_sleep => $sleep_between_try,
+    path      => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
   }
 }

--- a/modules/apim_store/manifests/init.pp
+++ b/modules/apim_store/manifests/init.pp
@@ -86,24 +86,6 @@ class apim_store inherits apim_store::params {
     source => "puppet:///modules/${module_name}/${product_binary}",
   }
 
-  # Stop the existing setup
-  exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
-  # Wait for the server to stop
-  exec { "wait":
-    command     => "sleep 10",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -d ${install_path}",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
   # Delete existing setup
   exec { "detele-pack":
     command     => "rm -rf ${install_path}",

--- a/modules/apim_store/manifests/params.pp
+++ b/modules/apim_store/manifests/params.pp
@@ -37,6 +37,10 @@ class apim_store::params {
 
   $start_script_template = 'bin/wso2server.sh'
 
+  # service stop retry and sleep times in seconds
+  $max_tries = 5
+  $sleep_between_try = 5
+
   # Directories
   $products_dir = "/usr/local/wso2"
 

--- a/modules/apim_store/manifests/startserver.pp
+++ b/modules/apim_store/manifests/startserver.pp
@@ -30,5 +30,6 @@ class apim_store::startserver (
     enable    => true,
     ensure    => running,
     subscribe => File["binary"],
+    require   => Exec['daemon-reload'],
   }
 }

--- a/modules/apim_store/manifests/stopserver.pp
+++ b/modules/apim_store/manifests/stopserver.pp
@@ -14,20 +14,16 @@
 #  limitations under the License.
 # ----------------------------------------------------------------------------
 
-# Class apim_analytics_dashboard::startserver
+# Class apim_store::stopserver
 # Starts the server as a service in the final stage.
-class apim_analytics_dashboard::startserver inherits apim_analytics_dashboard::params {
+class apim_store::stopserver (
+  $service_name = $apim_store::params::service_name
+)
+  inherits apim_store::params {
 
-  exec { 'daemon-reload':
-    command => "systemctl daemon-reload",
-    path    => "/bin/",
-  }
-
-  # Start the service
-  service { $service_name:
-    enable => true,
-    ensure => running,
-    subscribe => File["binary"],
-    require   => Exec['daemon-reload'],
+  exec { "systemctl stop ${service_name} ":
+    tries     => $max_try,
+    try_sleep => $sleep_between_try,
+    path      => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
   }
 }

--- a/modules/apim_tm/manifests/init.pp
+++ b/modules/apim_tm/manifests/init.pp
@@ -86,24 +86,6 @@ class apim_tm  inherits apim_tm::params {
     source => "puppet:///modules/${module_name}/${product_binary}",
   }
 
-  # Stop the existing setup
-  exec { "stop-server":
-    command     => "kill -term $(cat ${install_path}/wso2carbon.pid)",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -f ${install_path}/wso2carbon.pid",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
-  # Wait for the server to stop
-  exec { "wait":
-    command     => "sleep 10",
-    path        => "/bin/",
-    onlyif      => "/usr/bin/test -d ${install_path}",
-    subscribe   => File["binary"],
-    refreshonly => true,
-  }
-
   # Delete existing setup
   exec { "detele-pack":
     command     => "rm -rf ${install_path}",

--- a/modules/apim_tm/manifests/params.pp
+++ b/modules/apim_tm/manifests/params.pp
@@ -37,6 +37,10 @@ class apim_tm::params {
 
   $start_script_template = 'bin/wso2server.sh'
 
+  # service stop retry and sleep times in seconds
+  $max_tries = 5
+  $sleep_between_try = 5
+
   # Directories
   $products_dir = "/usr/local/wso2"
 

--- a/modules/apim_tm/manifests/startserver.pp
+++ b/modules/apim_tm/manifests/startserver.pp
@@ -30,5 +30,6 @@ class apim_tm::startserver (
     enable    => true,
     ensure    => running,
     subscribe => File["binary"],
+    require   => Exec['daemon-reload'],
   }
 }

--- a/modules/apim_tm/manifests/stopserver.pp
+++ b/modules/apim_tm/manifests/stopserver.pp
@@ -14,20 +14,16 @@
 #  limitations under the License.
 # ----------------------------------------------------------------------------
 
-# Class apim_analytics_dashboard::startserver
+# Class apim_tm::stopserver
 # Starts the server as a service in the final stage.
-class apim_analytics_dashboard::startserver inherits apim_analytics_dashboard::params {
+class apim_tm::stopserver (
+  $service_name = $apim_tm::params::service_name
+)
+  inherits apim_tm::params {
 
-  exec { 'daemon-reload':
-    command => "systemctl daemon-reload",
-    path    => "/bin/",
-  }
-
-  # Start the service
-  service { $service_name:
-    enable => true,
-    ensure => running,
-    subscribe => File["binary"],
-    require   => Exec['daemon-reload'],
+  exec { "systemctl stop ${service_name} ":
+    tries     => $max_try,
+    try_sleep => $sleep_between_try,
+    path      => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ],
   }
 }


### PR DESCRIPTION
## Purpose
Fixing the carbon server stop instead of killing the process and fixing the dependency in the serverstart.pp

## Goals
> Use of puppet stages

## Approach
> Introducing a new stage as `begin` to stop the carbon server.

## Issue
> https://github.com/wso2/puppet-apim/issues/105

