### PR TITLE
Fix templating errors for APIM 4.4.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ This repository contains the Puppet modules for profiles related to WSO2 API Man
 
 ## Supported Puppet Versions
 
-- Puppet 7.31.0
+- Puppet 7.35.0
 
 ## Quick Start Guide
 1. Download a product package. Product packages can be downloaded and copied to a local directory, or downloaded from a remote location.
-    * **Local**: Download wso2am-4.3.0.zip from [here](https://wso2.com/api-management/install/) and copy it to the `<puppet_environment>/modules/apim_common/files/packs` directory in the **Puppetmaster**.
+    * **Local**: Download wso2am-4.4.0.zip from [here](https://wso2.com/api-management/install/) and copy it to the `<puppet_environment>/modules/apim_common/files/packs` directory in the **Puppetmaster**.
     * **Remote**:
         1. Change the value *$pack_location* variable in `<puppet_environment>/modules/apim_common/manifests/params.pp` to `remote`.
         2. Change the value *$remote_pack* variable of the relevant profile in `<puppet_environment>/modules/apim_common/manifests/params.pp` to the URL in which the package should be downloaded from, and remove it as a comment.

--- a/modules/apim/templates/carbon-home/repository/conf/deployment.toml.erb
+++ b/modules/apim/templates/carbon-home/repository/conf/deployment.toml.erb
@@ -113,8 +113,8 @@ auth_token = "<%= @analytics_auth_token %>"
 
 [apim.ai]
 enable = <%= @ai_enabled %>
-token = <%= @ai_token %>
-endpoint = <%= @ai_endpoint %>
+token = "<%= @ai_token %>"
+endpoint = "<%= @ai_endpoint %>"
 
 [apim.key_manager]
 enable_apikey_subscription_validation = true

--- a/modules/apim_common/manifests/params.pp
+++ b/modules/apim_common/manifests/params.pp
@@ -17,7 +17,7 @@
 class apim_common::params {
 
   $packages = ["unzip"]
-  $version = "4.3.0"
+  $version = "4.4.0"
 
   # Set the location the product packages should reside in (eg: "local" in the /files directory, "remote" in a remote location)
   $pack_location = "local"

--- a/modules/apim_control_plane/templates/carbon-home/repository/conf/deployment.toml.erb
+++ b/modules/apim_control_plane/templates/carbon-home/repository/conf/deployment.toml.erb
@@ -103,8 +103,8 @@ websub_event_receiver_https_endpoint = "<%= environment['websub_event_receiver_h
 
 [apim.ai]
 enable = <%= @ai_enabled %>
-token = <%= @ai_token %>
-endpoint = <%= @ai_endpoint %>
+token = "<%= @ai_token %>"
+endpoint = "<%= @ai_endpoint %>"
 
 #[apim.key_manager]
 #service_url = "https://localhost:${mgt.transport.https.port}/services/"

--- a/modules/apim_gateway/templates/carbon-home/repository/conf/deployment.toml.erb
+++ b/modules/apim_gateway/templates/carbon-home/repository/conf/deployment.toml.erb
@@ -76,8 +76,8 @@ auth_token = "<%= @analytics_auth_token %>"
 
 [apim.ai]
 enable = <%= @ai_enabled %>
-token = <%= @ai_token %>
-endpoint = <%= @ai_endpoint %>
+token = "<%= @ai_token %>"
+endpoint = "<%= @ai_endpoint %>"
 
 # Caches
 [apim.cache.gateway_token]


### PR DESCRIPTION
## Purpose
> Fixing a templating syntax error in the current puppet scripts so that users can use the updated puppet script to configure APIM 4.4.0 without an issue
> Related Issue:
> - https://github.com/wso2-enterprise/wso2-apim-internal/issues/9546