### PR TITLE
Updating the README with refined puppet configuration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,61 +1,177 @@
 # Puppet Modules for WSO2 API Manager
 
-This repository contains the Puppet modules for profiles related to WSO2 API Manager and API Manager Analytics.
+This repository contains the Puppet modules for profiles related to WSO2 API Manager. 
+
+
 
 ## Supported Puppet Versions
 
-- Puppet 7.35.0
+- Puppet 8.x.x
 
-## Quick Start Guide
-1. Download a product package. Product packages can be downloaded and copied to a local directory, or downloaded from a remote location.
-    * **Local**: Download wso2am-4.4.0.zip from [here](https://wso2.com/api-management/install/) and copy it to the `<puppet_environment>/modules/apim_common/files/packs` directory in the **Puppetmaster**.
-    * **Remote**:
+## Manifests in a module
+
+Located in the modules directory, each subfolder represents a Puppet module for a specific API Manager profile or shared logic:
+
+- ```apim```: Main API Manager (default profile).
+- ```apim_gateway```: Gateway profile for handling API traffic.
+- ```apim_control_plane```: Control Plane profile for API publishing, management, and key management.
+- ```apim_tm```: Traffic Manager profile for throttling and rate limiting.
+- ```apim_common```: Shared logic, parameters, and files used by all profiles.
+
+![Module architecture](docs/images/module_architecture.png "Module architecture")
+
+The run stages for Puppet are described in `<puppet_environment>/manifests/site.pp`, and they are of the order Main -> Custom.
+
+Each Puppet module manifest contains the following .pp files.
+* Main
+    * ```params.pp```: Contains all the parameters necessary for the main configuration and template.
+    * ```init.pp```: Contains the main script of the module.
+* Custom
+    * ```custom.pp```: Used to add custom configurations to the Puppet module.
+
+## General Confiuration Steps
+
+1.Preparing the Puppet Environment:
+
+Before starting the configuration steps, Puppet environment should be created and the necessary modules, manifests, and scripts should be added:
+
+ -  **Clone or copy this repository into the Puppet environment directory**:
+    ```bash
+    git clone https://github.com/wso2/puppet-apim.git
+    ```
+- Ensure all required modules and manifests ( `apim`, `apim_gateway`, `apim_control_plane`, `apim_tm`, and `apim_common`) are present in the `modules` directory.
+<br>
+- Edit the agent's ```puppet.conf``` to use this copied/cloned directory as the environment.
+
+> **Note:**  
+> In the following instructions, the prepared Puppet environment directory will be referred to as `<puppet_environment>`.
+
+2. Download a product package. Product packages can be downloaded and copied to the directory manually, or downloaded from a remote location. Depending on the approach follow the relevant instruction.
+    * **Manual Approach**: Download wso2am-4.4.0.zip from [here](https://wso2.com/api-manager/previous-releases/) and copy it to the `<puppet_environment>/modules/apim_common/files/packs` directory in the **Puppetmaster**.
+    * **Download from Remote**:
         1. Change the value *$pack_location* variable in `<puppet_environment>/modules/apim_common/manifests/params.pp` to `remote`.
         2. Change the value *$remote_pack* variable of the relevant profile in `<puppet_environment>/modules/apim_common/manifests/params.pp` to the URL in which the package should be downloaded from, and remove it as a comment.
+<br>
+3. Set up the JDK distribution as follows:
 
-2. Set up the JDK distribution as follows:
-
-   The Puppet modules for WSO2 products use Amazon Corretto as the JDK distribution. However, you can use any [supported JDK distribution](https://apim.docs.wso2.com/en/latest/install-and-setup/setup/reference/product-compatibility/#tested-jdks). The JDK Distribution can be downloaded and copied to a local directory, or downloaded from a remote location.
-   * **local**: Download Amazon Corretto for Linux x64 from [here](https://corretto.aws/downloads/resources/17.0.6.10.1/amazon-corretto-17.0.6.10.1-linux-x64.tar.gz) and copy .tar into the `<puppet_environment>/modules/apim_common/files/jdk` directory.
-   * **remote**: Change the value *$remote_jdk* variable in `<puppet_environment>/modules/apim_common/manifests/params.pp` to the URL in which the JDK should be downloaded from, and remove it as a comment.
+   The Puppet modules for WSO2 products use Amazon Corretto as the JDK distribution. However, you can use any [supported JDK distribution](https://apim.docs.wso2.com/en/latest/install-and-setup/setup/reference/product-compatibility/#tested-jdks). Similar to the product pack, the JDK Distribution can also be downloaded and copied to the directory manually, or can be downloaded from a remote location.
+   * **Manual Approach**: Download Amazon Corretto for Linux x64 from [here](https://corretto.aws/downloads/resources/17.0.6.10.1/amazon-corretto-17.0.6.10.1-linux-x64.tar.gz) and copy .tar into the `<puppet_environment>/modules/apim_common/files/jdk` directory.
+   * **Download from Remote**: Change the value *$remote_jdk* variable in `<puppet_environment>/modules/apim_common/manifests/params.pp` to the URL in which the JDK should be downloaded from, and remove it as a comment.
    * To use a different jdk distribution, reassign the *$jdk_name* and the *$java_home* variables in `<puppet_environment>/modules/apim_common/manifests/params.pp` accordingly.
+<br>
+4. Depending on the Deployment Pattern going to be followed, add the necessary configurations in the modules in the **puppet server**. 
 
-3. Run the relevant profile on the **Puppet agent**.
-    1. Default profile:
+    - For that, populate the ```params.pp``` and the ```deployment.toml.erb``` within each module. Follow the Official APIM Documentation to find the required configurations that should be there in the deployment.toml for each profile.
+    
+        > [WSO2 API Manager Deployment Overview](https://apim.docs.wso2.com/en/4.4.0/install-and-setup/setup/deployment-overview/)
+        >    - [All-in-One Deployment Overview](https://apim.docs.wso2.com/en/4.4.0/install-and-setup/setup/single-node/all-in-one-deployment-overview/)
+        >        - [Configure Single Node Deployment](https://apim.docs.wso2.com/en/4.4.0/install-and-setup/setup/single-node/configuring-a-single-node/)
+        >        - [Configure Active - Active Deployment](https://apim.docs.wso2.com/en/4.4.0/install-and-setup/setup/single-node/configuring-an-active-active-deployment/)
+        >    - [Distributed Deployment Overview](https://apim.docs.wso2.com/en/4.4.0/install-and-setup/setup/distributed-deployment/understanding-the-distributed-deployment-of-wso2-api-m/)
+        >       - [Configuring a Distributed Deployment with Gateway and Control Plane](https://apim.docs.wso2.com/en/4.4.0/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup/)
+        >       - [Configuring a Distributed Deployment with Traffic Manager Separated from the Control Plane](https://apim.docs.wso2.com/en/4.4.0/install-and-setup/setup/distributed-deployment/deploying-wso2-api-m-in-a-distributed-setup-with-tm-separated/)
+
+    - Refer to the ```docs/samples/distributed_tm_seperated``` folder in this repo for some example params.pp and deployment.toml.erbs created for configuring a TM separated distributed API-M deployment using an external MySQL DB.
+<br>
+
+5. In the **agents**, the profile that is desired to be configured on it should be added and this can be done in two ways. 
+
+    ##### a. Using an Environment Variable (Ephemeral)
+
+    Set the profile for just the current session or command run. <i>**Note that this only applies for that session or command execution.**</i>
+
+    ```bash
+    export FACTER_profile=<PROFILE_NAME>
+    puppet agent -vt
+    ```
+
+
+    ##### b. Using an External Fact File (Persistent)
+
+    Create a file on the agent to always set the profile. This way it will persist across reboots and all agent runs.
+
+    ```bash
+    echo "profile=<PROFILE_NAME>" | sudo tee /etc/puppetlabs/facter/facts.d/profile.txt
+    puppet agent -vt
+    ```
+
+    Following are the ```PROFILE_NAME``` values that can be added depending on which profile that is intended to run on a particular **puppet agent**.
+    
+    - For Default Profile (All-in-one):
         ```bash
-        export FACTER_profile=apim
-        puppet agent -vt
+        profile=apim
         ```
-    2. Gateway profile:
+
+    - Gateway profile:
        ```bash
-       export FACTER_profile=apim_gateway
-       puppet agent -vt
+       profile=apim_gateway
        ```
-    3. Control Plane profile:
+    - Control Plane profile:
        ```bash
-       export FACTER_profile=apim_control_plane
-       puppet agent -vt
+       profile=apim_control_plane
        ```
-    4. Traffic Manager profile:
+    - Traffic Manager profile:
        ```bash
-       export FACTER_profile=apim_tm
-       puppet agent -vt
+       profile=apim_tm
        ```
+    
+6. After configuring the profile, to pull the configurations and run the relevant profile on the **puppet agent**.
+    ```bash
+    puppet agent -vt
+    ```
+
+    After running the profile, check the status of the service to ensure it is up and running.
 
 ## Performance Tuning
 System configurations can be changed through Puppet to optimize OS level performance. Performance tuning can be enabled by changing `$enable_performance_tuning` in `<puppet_environment>/modules/apim_common/manifests/params.pp` to `true`.
 
 System files that will be updated when performance tuning is enabled are available in `<puppet_environment>/modules/apim_common/files/system`. Update the configuration values according to the requirements of your deployment.
 
-## Manifests in a module
+## Common Issues & Possible Fixes
 
-![Module architecture](docs/images/module_architecture.png "Module architecture")
+1. **Permissions Issues:**
+The service runs as ```User=wso2carbon``` and ```Group=wso2```. Make sure ```/mnt/apim/wso2am-4.4.0/``` and all its contents are owned by ```wso2carbon:wso2``` and are writable by that user.
+    Fix:
+    ```bash
+    sudo chown -R wso2carbon:wso2 /mnt/<PROFILE_NAME>/wso2am-4.4.0
+    sudo chmod -R 755 /mnt/<PROFILE_NAME>/wso2am-4.4.0
+    ```
+<br>
 
-The run stages for Puppet are described in `<puppet_environment>/manifests/site.pp`, and they are of the order Main -> Custom.
+2. **JAVA_HOME Not Set or Java Not Installed:**
+The script expects JAVA_HOME to be set (it is set in the script, but make sure /opt/java exists and points to a valid JDK). Make sure Java is installed and accessible to the wso2carbon user.
+    Fix:
+    ```bash
+    sudo -u wso2carbon /opt/java/bin/java -version
+    ```
+    - If this fails, check your JDK installation and symlink.
+<br>
 
-Each Puppet module contains the following .pp files.
-* Main
-    * params.pp: Contains all the parameters necessary for the main configuration and template.
-    * init.pp: Contains the main script of the module.
-* Custom
-    * custom.pp: Used to add custom configurations to the Puppet module.
+3. **Script Fails Silently:**
+The api-manager.sh script may exit early due to a missing dependency or misconfiguration, so the PID file is never created.
+    Fix:
+    - Try running the script manually as the wso2carbon user and see if it starts or prints errors:
+        ```bash
+        sudo -u wso2carbon /mnt/<PROFILE_NAME>/wso2am-4.4.0/bin/api-manager.sh start
+        ```
+    - Check for errors in ```/mnt/<PROFILE_NAME>/wso2am-4.4.0/repository/logs/wso2carbon.log``` or similar log files.
+<br>
+
+4. **Systemd Type Mismatch:**
+The service is defined as ```Type=forking```, which expects the script to fork and leave a process running in the background, and to write a PID file. If the script does not fork or does not write the PID file, systemd will kill it.
+    Fix:
+    > Confirm that the script actually forks and writes the PID file.
+
+---
+
+## Get Involved
+
+We welcome contributions and engagement from the community! If you are interested in reporting issues, suggesting features, or contributing code to this repository, please review our [CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines.
+
+**How you can participate:**
+- **Report Issues:** If you encounter bugs or have feature requests, please open an issue on our [GitHub Issues page](https://github.com/wso2/puppet-apim/issues).
+- **Join Discussions:** Use the WSO2 mailing lists to discuss ideas, ask questions, or get help from the community.
+
+For more details on the contribution process, coding standards, and communication channels, see [CONTRIBUTING.md](CONTRIBUTING.md).
+
+Thank you for your interest in making puppet-apim better!

--- a/docs/samples/distributed_tm_seperated/modules/apim_common/params.pp
+++ b/docs/samples/distributed_tm_seperated/modules/apim_common/params.pp
@@ -1,0 +1,178 @@
+#----------------------------------------------------------------------------
+#  Copyright (c) 2021 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#----------------------------------------------------------------------------
+
+class apim_common::params {
+
+  $packages = ["unzip"]
+  $version = "4.4.0"
+
+  # Set the location the product packages should reside in (eg: "local" in the /files directory, "remote" in a remote location)
+  $pack_location = "local"
+  # $pack_location = "remote"
+  # $remote_jdk = "<URL_TO_JDK_FILE>"
+
+  $user = 'wso2carbon'
+  $user_group = 'wso2'
+  $user_id = 802
+  $user_group_id = 802
+
+  # Performance tuning configurations
+  $enable_performance_tuning = false
+  $performance_tuning_flie_list = [
+    'etc/sysctl.conf',
+    'etc/security/limits.conf',
+  ]
+
+  # JDK Distributions
+  $java_dir = "/opt"
+  $java_symlink = "${java_dir}/java"
+  $jdk_name = 'amazon-corretto-17.0.6.10.1-linux-x64'
+  $java_home = "${java_dir}/${jdk_name}"
+
+  $profile = $profile
+  $target = "/mnt"
+  $product_dir = "${target}/${profile}"
+  $pack_dir = "${target}/${profile}/packs"
+  $wso2_service_name = "wso2${profile}"
+
+  # ----- Profile configs -----
+  case $profile {
+    'apim_gateway': {
+      $pack = "wso2am-${version}"
+      # $remote_pack = "<URL_TO_APIM_GATEWAY_PACK>"
+      $server_script_path = "${product_dir}/${pack}/bin/api-manager.sh"
+      $pid_file_path = "${product_dir}/${pack}/wso2carbon.pid"
+      $optimize_params = "-Dprofile=gateway-worker"
+    }
+    'apim_control_plane': {
+      $pack = "wso2am-${version}"
+      # $remote_pack = "<URL_TO_APIM_CONTROL_PLANE_PACK>"
+      $server_script_path = "${product_dir}/${pack}/bin/api-manager.sh"
+      $pid_file_path = "${product_dir}/${pack}/wso2carbon.pid"
+      $optimize_params = "-Dprofile=control-plane"
+    }
+    'apim_tm': {
+      $pack = "wso2am-${version}"
+      # $remote_pack = "<URL_TO_APIM_TRAFFICMANAGER_PACK>"
+      $server_script_path = "${product_dir}/${pack}/bin/api-manager.sh"
+      $pid_file_path = "${product_dir}/${pack}/wso2carbon.pid"
+      $optimize_params = "-Dprofile=traffic-manager"
+    }
+    default: {
+      $pack = "wso2am-${version}"
+      # $remote_pack = "<URL_TO_APIM_PACK>"
+      $server_script_path = "${product_dir}/${pack}/bin/api-manager.sh"
+      $pid_file_path = "${product_dir}/${pack}/wso2carbon.pid"
+      $optimize_params = ""
+    }
+  }
+
+  # Pack Directories
+  $carbon_home = "${product_dir}/${pack}"
+  $product_binary = "${pack}.zip"
+
+  # Server stop retry configs
+  $try_count = 5
+  $try_sleep = 5
+
+  # ----- api-manager.xml config params -----
+  $analytics_enabled = 'false'
+  $analytics_config_endpoint = 'https://localhost:8080/auth/v1'
+  $analytics_auth_token = ''
+
+  $ai_enabled = 'true'
+  $ai_endpoint = ''
+  $ai_token = ''
+
+  $throttle_decision_endpoints = '"tcp://tm.wso2.com:5672"'
+  $throttling_url_group = [
+    {
+      traffic_manager_urls      => '"tcp://tm.wso2.com:9611"',
+      traffic_manager_auth_urls => '"ssl://tm.wso2.com:9711"'
+    }
+  ]
+
+  $gateway_environments = [
+    {
+      type                                  => 'hybrid',
+      name                                  => 'Default',
+      gateway_type                          => 'Regular',
+      provider                              => 'wso2',
+      description                           => 'This is a hybrid gateway that handles both production and sandbox token traffic.',
+      server_url                            => 'https://gw.wso2.com:${mgt.transport.https.port}${carbon.context}services/',
+      ws_endpoint                           => 'ws://gw.wso2.com:9099',
+      wss_endpoint                          => 'wss://gw.wso2.com:8099',
+      http_endpoint                         => 'http://gw.wso2.com:8280',
+      https_endpoint                        => 'https://gw.wso2.com:8243',
+      websub_event_receiver_http_endpoint   => 'http://localhost:9021',
+      websub_event_receiver_https_endpoint  => 'https://localhost:8021'
+    }
+  ]
+
+  $gateway_labels = ["Default"]
+
+  $key_manager_server_url = 'https://cp.wso2.com:${mgt.transport.https.port}${carbon.context}services/'
+  $key_validator_thrift_server_host = 'localhost'
+
+  $api_devportal_url = 'https://cp.wso2.com:${mgt.transport.https.port}/devportal'
+  $throttle_service_url = 'https://tm.wso2.com:${mgt.transport.https.port}${carbon.context}services/'
+
+  $traffic_manager_receiver_url = 'tcp://${carbon.local.ip}:${receiver.url.port}'
+  $traffic_manager_auth_url = 'ssl://${carbon.local.ip}:${auth.url.port}'
+
+  # ----- Master-datasources config params -----
+
+  $wso2am_db_url = 'jdbc:mysql://<DB_HOST>:3306/apim_db?useSSL=false'
+  $wso2am_db_username = 'apimadmin'
+  $wso2am_db_password = 'apimadmin'
+  $wso2am_db_type = 'mysql'
+  $wso2am_db_validation_query = 'SELECT 1'
+
+  $wso2shared_db_url = 'jdbc:mysql://<DB_HOST>:3306/shared_db?useSSL=false'
+  $wso2shared_db_username = 'sharedadmin'
+  $wso2shared_db_password = 'sharedadmin'
+  $wso2shared_db_type = 'mysql'
+  $wso2shared_db_validation_query = 'SELECT 1'
+
+  # ----- Carbon.xml config params -----
+  $ports_offset = 0
+
+  $key_store_location = 'wso2carbon.jks'
+  $analytics_key_store_location = '${sys:carbon.home}/resources/security/wso2carbon.jks'
+  $key_store_password = 'wso2carbon'
+  $key_store_key_alias = 'wso2carbon'
+  $key_store_key_password = 'wso2carbon'
+
+  $internal_keystore_location = 'wso2carbon.jks'
+  $internal_keystore_password = 'wso2carbon'
+  $internal_keystore_key_alias = 'wso2carbon'
+  $internal_keystore_key_password = 'wso2carbon'
+
+  $trust_store_location = 'client-truststore.jks'
+  $analytics_trust_store_location = '${sys:carbon.home}/resources/security/client-truststore.jks'
+  $trust_store_password = 'wso2carbon'
+
+  # ----- user-mgt.xml config params -----
+  $admin_username = 'admin'
+  $admin_password = 'admin'
+
+  $event_listener_notification_endpoint = 'https://localhost:${mgt.transport.https.port}/internal/data/v1/notify'
+
+  $token_exchange_enable = true
+  $token_exchange_allow_refresh_tokens = true
+  $token_exchange_iat_validity_period = '1h'
+
+}

--- a/docs/samples/distributed_tm_seperated/modules/apim_control_plane/deplyment.toml.erb
+++ b/docs/samples/distributed_tm_seperated/modules/apim_control_plane/deplyment.toml.erb
@@ -1,0 +1,238 @@
+[server]
+hostname = "<%= @hostname %>"
+base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
+#discard_empty_caches = false
+server_role = "control-plane"
+offset = "<%= @ports_offset %>"
+
+[super_admin]
+username = "<%= @admin_username %>"
+password = "<%= @admin_password %>"
+create_admin_account = true
+
+[user_store]
+type = "database_unique_id"
+
+[database.apim_db]
+type = "<%= @wso2am_db_type %>"
+url = "<%= @wso2am_db_url %>"
+username = "<%= @wso2am_db_username %>"
+password = "<%= @wso2am_db_password %>"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[database.apim_db.pool_options]
+validationQuery = "<%= @wso2am_db_validation_query %>"
+
+[database.shared_db]
+type = "<%= @wso2shared_db_type %>"
+url = "<%= @wso2shared_db_url %>"
+username = "<%= @wso2shared_db_username %>"
+password = "<%= @wso2shared_db_password %>"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[database.shared_db.pool_options]
+validationQuery = "<%= @wso2shared_db_validation_query %>"
+
+[keystore.tls]
+file_name =  "<%= @key_store_location %>"
+type =  "JKS"
+password =  "<%= @key_store_password %>"
+alias =  "<%= @key_store_key_alias %>"
+key_password =  "<%= @key_store_key_password %>"
+
+#[keystore.primary]
+#file_name =  "wso2carbon.jks"
+#type =  "JKS"
+#password =  "wso2carbon"
+#alias =  "wso2carbon"
+#key_password =  "wso2carbon"
+
+#[keystore.internal]
+#file_name =  "wso2carbon.jks"
+#type =  "JKS"
+#password =  "wso2carbon"
+#alias =  "wso2carbon"
+#key_password =  "wso2carbon"
+
+<% @gateway_environments.each do |environment| %>
+[[apim.gateway.environment]]
+name = "<%= environment['name'] %>"
+type = "<%= environment['type'] %>"
+gateway_type = "<%= environment['gateway_type'] %>"
+provider = "<%= environment['provider'] %>"
+display_in_api_console = true
+description = "<%= environment['description'] %>"
+show_as_token_endpoint_url = true
+service_url = "<%= environment['server_url'] %>"
+username= "${admin.username}"
+password= "${admin.password}"
+ws_endpoint = "<%= environment['ws_endpoint'] %>"
+wss_endpoint = "<%= environment['wss_endpoint'] %>"
+http_endpoint = "<%= environment['http_endpoint'] %>"
+https_endpoint = "<%= environment['https_endpoint'] %>"
+websub_event_receiver_http_endpoint = "<%= environment['websub_event_receiver_http_endpoint'] %>"
+websub_event_receiver_https_endpoint = "<%= environment['websub_event_receiver_https_endpoint'] %>"
+<% end %>
+
+# Event Hub configurations
+[apim.event_hub]
+enable = true
+username= "$ref{super_admin.username}"
+password= "$ref{super_admin.password}"
+service_url = "https://cp.wso2.com:${mgt.transport.https.port}/services/"
+event_listening_endpoints = ["tcp://cp.wso2.com:5672"]
+
+[[apim.event_hub.publish.url_group]]
+urls = ["tcp://cp.wso2.com:9611"]
+auth_urls = ["ssl://cp.wso2.com:9711"]
+
+#[apim.cache.gateway_token]
+#enable = true
+#expiry_time = "900s"
+
+#[apim.cache.resource]
+#enable = true
+#expiry_time = "900s"
+
+#[apim.cache.km_token]
+#enable = false
+#expiry_time = "15m"
+
+#[apim.cache.recent_apis]
+#enable = false
+
+#[apim.cache.scopes]
+#enable = true
+
+#[apim.cache.publisher_roles]
+#enable = true
+
+#[apim.cache.jwt_claim]
+#enable = true
+#expiry_time = "15m"
+
+#[apim.cache.tags]
+#expiry_time = "2m"
+
+[apim.ai]
+enable = <%= @ai_enabled %>
+token = "<%= @ai_token %>"
+endpoint = "<%= @ai_endpoint %>"
+
+#[apim.key_manager]
+#service_url = "https://localhost:${mgt.transport.https.port}/services/"
+#username = "$ref{super_admin.username}"
+#password = "$ref{super_admin.password}"
+#pool.init_idle_capacity = 50
+#pool.max_idle = 100
+#key_validation_handler_type = "default"
+#key_validation_handler_type = "custom"
+#key_validation_handler_impl = "org.wso2.carbon.apimgt.keymgt.handlers.DefaultKeyValidationHandler"
+
+#[apim.oauth_config]
+#enable_outbound_auth_header = false
+#auth_header = "Authorization"
+#revoke_endpoint = "https://localhost:${https.nio.port}/revoke"
+#enable_token_encryption = false
+#enable_token_hashing = false
+
+#[apim.devportal]
+#url = "https://localhost:${mgt.transport.https.port}/devportal"
+#enable_application_sharing = false
+#if application_sharing_type, application_sharing_impl both defined priority goes to application_sharing_impl
+#application_sharing_type = "default" #changed type, saml, default #todo: check the new config for rest api
+#application_sharing_impl = "org.wso2.carbon.apimgt.impl.SAMLGroupIDExtractorImpl"
+#display_multiple_versions = false
+#display_deprecated_apis = false
+#enable_comments = true
+#enable_ratings = true
+#enable_forum = true
+#enable_anonymous_mode=true
+#enable_cross_tenant_subscriptions = true
+#default_reserved_username = "apim_reserved_user"
+
+[apim.cors]
+allow_origins = "*"
+allow_methods = ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
+allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction","apikey","Internal-Key"]
+allow_credentials = false
+
+#[apim.throttling]
+#service_url = "<%= @throttle_service_url %>"
+#enable_data_publishing = true
+#enable_policy_deploy = true
+#enable_blacklist_condition = true
+#enable_persistence = true
+#throttle_decision_endpoints = [ <%= @throttle_decision_endpoints %> ]
+
+#<% @throttling_url_group.each do |url_group| %>
+#[[apim.throttling.url_group]]
+#traffic_manager_urls=[<%= url_group['traffic_manager_urls'] %>]
+#traffic_manager_auth_urls=[<%= url_group['traffic_manager_auth_urls'] %>]
+#type = "loadbalance"
+#<% end %>
+
+#[apim.workflow]
+#enable = false
+#service_url = "https://localhost:9445/bpmn"
+#username = "$ref{super_admin.username}"
+#password = "$ref{super_admin.password}"
+#callback_endpoint = "https://localhost:${mgt.transport.https.port}/api/am/admin/v0.17/workflows/update-workflow-status"
+#token_endpoint = "https://localhost:${https.nio.port}/token"
+#client_registration_endpoint = "https://localhost:${mgt.transport.https.port}/client-registration/v0.17/register"
+#client_registration_username = "$ref{super_admin.username}"
+#client_registration_password = "$ref{super_admin.password}"
+
+#data bridge config
+#[transport.receiver]
+#type = "binary"
+#worker_threads = 10
+#session_timeout = "30m"
+#keystore.file_name = "$ref{keystore.tls.file_name}"
+#keystore.password = "$ref{keystore.tls.password}"
+#tcp_port = 9611
+#ssl_port = 9711
+#ssl_receiver_thread_pool_size = 100
+#tcp_receiver_thread_pool_size = 100
+#ssl_enabled_protocols = ["TLSv1","TLSv1.1","TLSv1.2"]
+#ciphers = ["SSL_RSA_WITH_RC4_128_MD5","SSL_RSA_WITH_RC4_128_SHA"]
+
+#[apim.notification]
+#from_address = "APIM.com"
+#username = "APIM"
+#password = "APIM+123"
+#hostname = "localhost"
+#port = 3025
+#enable_start_tls = false
+#enable_authentication = true
+
+#[apim.token.revocation]
+#notifier_impl = "org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl"
+#enable_realtime_notifier = true
+#realtime_notifier.ttl = 5000
+#enable_persistent_notifier = true
+#persistent_notifier.hostname = "https://localhost:2379/v2/keys/jti/"
+#persistent_notifier.ttl = 5000
+#persistent_notifier.username = "root"
+#persistent_notifier.password = "root"
+
+[[event_handler]]
+name="userPostSelfRegistration"
+subscriptions=["POST_ADD_USER"]
+
+[service_provider]
+sp_name_regex = "^[\\sa-zA-Z0-9._-]*$"
+
+#[database.local]
+#url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+
+[[event_listener]]
+id = "token_revocation"
+type = "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+name = "org.wso2.is.notification.ApimOauthEventInterceptor"
+order = 1
+[event_listener.properties]
+notification_endpoint = "<%= @event_listener_notification_endpoint %>"
+username = "${admin.username}"
+password = "${admin.password}"
+'header.X-WSO2-KEY-MANAGER' = "default"

--- a/docs/samples/distributed_tm_seperated/modules/apim_control_plane/params.pp
+++ b/docs/samples/distributed_tm_seperated/modules/apim_control_plane/params.pp
@@ -1,0 +1,44 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2021 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class apim_control_plane::params
+# This class includes all the necessary parameters.
+class apim_control_plane::params inherits apim_common::params {
+
+  $start_script_template = 'bin/api-manager.sh'
+  $jvmxms = '1024m'
+  $jvmxmx = '2048m'
+
+  $template_list = [
+    'repository/conf/deployment.toml',
+  ]
+
+  # Define file list
+  $file_list = []
+
+  # Define remove file list
+  $file_removelist = []
+
+  # ----- Carbon.xml config params -----
+  $ports_offset = 0
+  /*
+     Host name or IP address of the machine hosting this server
+     e.g. www.wso2.org, 192.168.1.10
+     This is will become part of the End Point Reference of the
+     services deployed on this server instance.
+  */
+  $hostname = 'cp.wso2.com'
+}

--- a/docs/samples/distributed_tm_seperated/modules/apim_gateway/deplyment.toml.erb
+++ b/docs/samples/distributed_tm_seperated/modules/apim_gateway/deplyment.toml.erb
@@ -1,0 +1,110 @@
+[server]
+hostname = "<%= @hostname %>"
+server_role = "gateway-worker"
+offset = "<%= @ports_offset %>"
+
+[user_store]
+type = "database_unique_id"
+
+[super_admin]
+username = "<%= @admin_username %>"
+password = "<%= @admin_password %>"
+create_admin_account = true
+
+[database.shared_db]
+type = "<%= @wso2shared_db_type %>"
+url = "<%= @wso2shared_db_url %>"
+username = "<%= @wso2shared_db_username %>"
+password = "<%= @wso2shared_db_password %>"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[database.shared_db.pool_options]
+validationQuery = "<%= @wso2shared_db_validation_query %>"
+
+[keystore.tls]
+file_name =  "<%= @key_store_location %>"
+type =  "JKS"
+password =  "<%= @key_store_password %>"
+alias =  "<%= @key_store_key_alias %>"
+key_password =  "<%= @key_store_key_password %>"
+
+[truststore]
+file_name = "<%= @trust_store_location %>"
+type = "JKS"
+password = "<%= @trust_store_password %>"
+
+[apim.sync_runtime_artifacts.gateway]
+gateway_labels = <%= @gateway_labels %>
+
+# key manager implementation
+[apim.key_manager]
+service_url = "<%= @key_manager_server_url %>"
+username= "$ref{super_admin.username}"
+password= "$ref{super_admin.password}"
+
+# JWT Generation
+#[apim.jwt]
+#enable = true
+#encoding = "base64" # base64,base64url
+#generator_impl = "org.wso2.carbon.apimgt.keymgt.token.JWTGenerator"
+#claim_dialect = "http://wso2.org/claims"
+#header = "X-JWT-Assertion"
+#signing_algorithm = "SHA256withRSA"
+#enable_user_claims = true
+#claims_extractor_impl = "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever"
+
+# Traffic Manager configurations
+[apim.throttling]
+username= "$ref{super_admin.username}"
+password= "$ref{super_admin.password}"
+service_url = "<%= @throttle_service_url %>"
+throttle_decision_endpoints = [<%= @throttle_decision_endpoints %>]
+#enable_unlimited_tier = true
+#enable_header_based_throttling = false
+#enable_jwt_claim_based_throttling = false
+#enable_query_param_based_throttling = false
+
+[apim.event_hub]
+enable = true
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+service_url = "https://cp.wso2.com:${mgt.transport.https.port}/services/"
+event_listening_endpoints = ["tcp://cp.wso2.com:5672"]
+
+<% @throttling_url_group.each do |url_group| %>
+[[apim.throttling.url_group]]
+traffic_manager_urls=[<%= url_group['traffic_manager_urls'] %>]
+traffic_manager_auth_urls=[<%= url_group['traffic_manager_auth_urls'] %>]
+<% end %>
+
+[apim.analytics]
+enable = <%= @analytics_enabled %>
+config_endpoint = "<%= @analytics_config_endpoint %>"
+auth_token = "<%= @analytics_auth_token %>"
+
+[apim.ai]
+enable = <%= @ai_enabled %>
+token = "<%= @ai_token %>"
+endpoint = "<%= @ai_endpoint %>"
+
+# Caches
+[apim.cache.gateway_token]
+enable = true
+expiry_time = 15
+
+[apim.cache.resource]
+enable = true
+
+[apim.cache.jwt_claim]
+enable = true
+expiry_time = 900
+
+[apim.oauth_config]
+remove_outbound_auth_header = true
+auth_header = "Authorization"
+
+[apim.cors]
+allow_origins = "*"
+allow_methods = ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
+allow_headers = ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction","apikey","Internal-Key"]
+allow_credentials = false

--- a/docs/samples/distributed_tm_seperated/modules/apim_gateway/params.pp
+++ b/docs/samples/distributed_tm_seperated/modules/apim_gateway/params.pp
@@ -1,0 +1,47 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2021 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Class apim_gateway::params
+# This class includes all the necessary parameters.
+class apim_gateway::params inherits apim_common::params {
+
+  $start_script_template = 'bin/api-manager.sh'
+  $jvmxms = '1024m'
+  $jvmxmx = '2048m'
+
+  $template_list = [
+    'repository/conf/deployment.toml',
+  ]
+
+  # Define file list
+  $file_list = []
+
+  # Define remove file list
+  $file_removelist = []
+
+  # ----- Carbon.xml config params -----
+  $ports_offset = 0
+  /*
+     Host name or IP address of the machine hosting this server
+     e.g. www.wso2.org, 192.168.1.10
+     This is will become part of the End Point Reference of the
+     services deployed on this server instance.
+  */
+  $hostname = 'gw.wso2.com'
+
+  # ----- api-manager.xml config params -----
+  $jms_conn_factory = 'amqp://${admin.username}:${admin.password}@clientid/carbon?brokerlist=\'tcp://${carbon.local.ip}:${jms.port}\''
+}

--- a/docs/samples/distributed_tm_seperated/modules/apim_tm/deplyment.toml.erb
+++ b/docs/samples/distributed_tm_seperated/modules/apim_tm/deplyment.toml.erb
@@ -1,0 +1,61 @@
+[server]
+hostname = "<%= @hostname %>"
+server_role = "traffic-manager"
+offset = "<%= @ports_offset %>"
+
+[user_store]
+type = "database_unique_id"
+
+[super_admin]
+username = "<%= @admin_username %>"
+password = "<%= @admin_password %>"
+create_admin_account = true
+
+[database.apim_db]
+type = "<%= @wso2am_db_type %>"
+url = "<%= @wso2am_db_url %>"
+username = "<%= @wso2am_db_username %>"
+password = "<%= @wso2am_db_password %>"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[database.apim_db.pool_options]
+validationQuery = "<%= @wso2am_db_validation_query %>"
+
+[database.shared_db]
+type = "<%= @wso2shared_db_type %>"
+url = "<%= @wso2shared_db_url %>"
+username = "<%= @wso2shared_db_username %>"
+password = "<%= @wso2shared_db_password %>"
+driver = "com.mysql.cj.jdbc.Driver"
+
+[database.shared_db.pool_options]
+validationQuery = "<%= @wso2shared_db_validation_query %>"
+
+[keystore.tls]
+file_name =  "<%= @key_store_location %>"
+type =  "JKS"
+password =  "<%= @key_store_password %>"
+alias =  "<%= @key_store_key_alias %>"
+key_password =  "<%= @key_store_key_password %>"
+
+[truststore]
+file_name = "<%= @trust_store_location %>"
+type = "JKS"
+password = "<%= @trust_store_password %>"
+
+# key manager implementation
+#[apim.key_manager]
+#service_url = "<%= @key_manager_server_url %>"
+
+#[apim.oauth_config]
+#revoke_endpoint = "<%= @oauth_configs_revoke_api_url %>"
+#enable_token_encryption = false
+#enable_token_hashing = false
+
+# Event Hub configurations
+[apim.event_hub]
+enable = true
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+service_url = "https://cp.wso2.com:9443/services/"
+event_listening_endpoints = ["tcp://cp.wso2.com:5672"]

--- a/docs/samples/distributed_tm_seperated/modules/apim_tm/params.pp
+++ b/docs/samples/distributed_tm_seperated/modules/apim_tm/params.pp
@@ -1,0 +1,44 @@
+# ----------------------------------------------------------------------------
+#  Copyright (c) 2021 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# ----------------------------------------------------------------------------
+
+# Claas apim_tm::params
+# This class includes all the necessary parameters.
+class apim_tm::params inherits apim_common::params {
+
+  $start_script_template = 'bin/api-manager.sh'
+  $jvmxms = '1024m'
+  $jvmxmx = '2048m'
+
+  $template_list = [
+    'repository/conf/deployment.toml',
+  ]
+
+  # Define file list
+  $file_list = []
+
+  # Define remove file list
+  $file_removelist = []
+
+  # ----- Carbon.xml config params -----
+  $ports_offset = 0
+  /*
+     Host name or IP address of the machine hosting this server
+     e.g. www.wso2.org, 192.168.1.10
+     This is will become part of the End Point Reference of the
+     services deployed on this server instance.
+  */
+  $hostname = 'tm.wso2.com'
+}


### PR DESCRIPTION
## Purpose
> Current README file contains only a minimal set of instruction for configuring the WSO2 API-M using the puppet modules. Hence it is modified with more clear instructions along with some sample values.
Related Issue:
- https://github.com/wso2-enterprise/wso2-apim-internal/issues/9546
